### PR TITLE
chore: rename package to datahub-analytics-agent + add PyPI metadata

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 RUN pip install uv
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 COPY backend/ backend/
 
 RUN uv sync --no-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 requires-python = ">=3.11"
-
-[project.urls]
-Homepage = "https://github.com/datahub-project/analytics-agent"
-Repository = "https://github.com/datahub-project/analytics-agent"
-"Bug Tracker" = "https://github.com/datahub-project/analytics-agent/issues"
 dependencies = [
     # Web
     "fastapi>=0.115.0",
@@ -64,6 +59,11 @@ dependencies = [
     "keyring>=25.7.0",
     "langchain-google-genai>=4.2.2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/datahub-project/analytics-agent"
+Repository = "https://github.com/datahub-project/analytics-agent"
+"Bug Tracker" = "https://github.com/datahub-project/analytics-agent/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,28 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "datahub-talk-to-data"
+name = "datahub-analytics-agent"
 version = "0.1.0"
-description = "LangGraph-based talk-to-data agent with DataHub context and pluggable query engines"
+description = "Open-source talk-to-data agent with DataHub context and pluggable query engines"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+authors = [{ name = "DataHub Project", email = "datahub-project@acryldata.io" }]
+keywords = ["datahub", "analytics", "agent", "llm", "text-to-sql", "langgraph"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 requires-python = ">=3.11"
+
+[project.urls]
+Homepage = "https://github.com/datahub-project/analytics-agent"
+Repository = "https://github.com/datahub-project/analytics-agent"
+"Bug Tracker" = "https://github.com/datahub-project/analytics-agent/issues"
 dependencies = [
     # Web
     "fastapi>=0.115.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Open-source talk-to-data agent with DataHub context and pluggable query engines"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-authors = [{ name = "DataHub Project", email = "datahub-project@acryldata.io" }]
+authors = [{ name = "DataHub Project" }]
 keywords = ["datahub", "analytics", "agent", "llm", "text-to-sql", "langgraph"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- Renames package from internal `datahub-talk-to-data` to the canonical OSS name `datahub-analytics-agent`
- Adds `license`, `authors`, `classifiers`, and `[project.urls]` in preparation for PyPI publishing
- No functional changes — purely packaging metadata

## Follow-up

A separate PR will add `.github/workflows/publish.yml` to auto-publish to PyPI on `v*` tags via GitHub OIDC trusted publishing (no secrets required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)