### PR TITLE
docs: add node and just to manual setup prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 ## ⚡ Quickstart
 
 > **Requires:** Docker, DataHub CLI (`pip install acryl-datahub`), `uv`, Python 3.11+
->
-> **Manual setup also requires:** `node` and `just` (`brew install node just`)
 
 ```bash
 git clone https://github.com/datahub-project/analytics-agent.git
@@ -69,6 +67,8 @@ Open the browser — a setup wizard walks you through naming your agent, picking
 ---
 
 ## Manual setup (without quickstart.sh)
+
+> **Manual setup also requires:** `node` and `just` (`brew install node just`)
 
 ### 1. Clone and install
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 ## ⚡ Quickstart
 
 > **Requires:** Docker, DataHub CLI (`pip install acryl-datahub`), `uv`, Python 3.11+
+>
+> **Manual setup also requires:** `node` and `just` (`brew install node just`)
 
 ```bash
 git clone https://github.com/datahub-project/analytics-agent.git


### PR DESCRIPTION
Fixes #1

Adds missing prerequisites (`node` and `just`) to the manual setup
requirements section to prevent setup issues for users.