### PR TITLE
chore: remove internal name references from docs and metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ uv run python -c "import analytics_agent.main"
 uv run pytest tests/unit/ -v
 
 # Test the full agent pipeline (needs credentials)
-cd /path/to/talkster && set -a && source .env && set +a && \
+cd /path/to/analytics-agent && set -a && source .env && set +a && \
 uv run pytest tests/integration/ -v -s
 ```
 

--- a/backend/src/analytics_agent/skills/improve-context/SKILL.md
+++ b/backend/src/analytics_agent/skills/improve-context/SKILL.md
@@ -2,7 +2,7 @@
 name: improve_context
 description: Use this skill when the user types /improve-context or asks to capture learnings, improve documentation, or enrich the knowledge base based on this conversation.
 metadata:
-  author: talkster
+  author: analytics-agent
   version: "1.0"
 ---
 

--- a/backend/src/analytics_agent/skills/publish-analysis/SKILL.md
+++ b/backend/src/analytics_agent/skills/publish-analysis/SKILL.md
@@ -9,7 +9,7 @@ license: MIT
 compatibility: Requires DataHub write-back enabled in Settings → Connections
 allowed-tools: search_documents, get_entities, publish_analysis
 metadata:
-  author: talkster
+  author: analytics-agent
   version: "1.0"
 ---
 

--- a/backend/src/analytics_agent/skills/save-correction/SKILL.md
+++ b/backend/src/analytics_agent/skills/save-correction/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: Requires DataHub write-back enabled in Settings → Connections
 allowed-tools: search, get_entities, list_schema_fields, search_documents, save_correction
 metadata:
-  author: talkster
+  author: analytics-agent
   version: "2.0"
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "datahub-talk-to-data-ui",
+  "name": "datahub-analytics-agent-ui",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,7 +37,7 @@ def test_context_platform_config_full():
     assert plat.token == "tok123"
 
 
-def test_talkster_yaml_config_parse():
+def test_yaml_config_parse():
     data = {
         "engines": [{"type": "snowflake", "name": "prod", "connection": {"account": "xy12345"}}],
         "context_platforms": [
@@ -52,7 +52,7 @@ def test_talkster_yaml_config_parse():
     assert cfg.context_platforms[0].url == "http://localhost:8080"
 
 
-def test_talkster_yaml_config_empty():
+def test_yaml_config_empty():
     cfg = AnalyticsAgentYamlConfig.model_validate({})
     assert cfg.engines == []
     assert cfg.context_platforms == []


### PR DESCRIPTION
## Summary

Scrubs internal project name references from documentation and metadata files only. Runtime artifacts (docker-compose.yml, quickstart.sh) are intentionally unchanged — their rename requires a one-time migration path that will be implemented on top of the bootstrap CLI (PR #12).

| File | Was | Now |
|---|---|---|
| `CLAUDE.md` | `/path/to/talkster` | `/path/to/analytics-agent` |
| `frontend/package.json` | `datahub-talk-to-data-ui` | `datahub-analytics-agent-ui` |
| `tests/unit/test_config.py` | `test_talkster_yaml_config_*` | `test_yaml_config_*` |
| `skills/*/SKILL.md` (×3) | `author: talkster` | `author: analytics-agent` |

## What's deferred

`docker-compose.yml` (Postgres credentials/db) and `quickstart.sh` (MySQL schema + DATABASE_URL) renames are deferred to avoid silently breaking existing installations. The migration will be added as part of `analytics-agent migrate` on top of PR #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)