### PR TITLE
feat: add AWS Bedrock provider + bump langchain to 1.x

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DATAHUB_GMS_URL=http://localhost:8080
 DATAHUB_GMS_TOKEN=
 
-# LLM — set LLM_PROVIDER to "openai" or "anthropic"
+# LLM — set LLM_PROVIDER to "openai", "anthropic", "google", or "bedrock"
 LLM_PROVIDER=openai
 
 # OpenAI (used when LLM_PROVIDER=openai)
@@ -14,6 +14,19 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 # LLM_MODEL=claude-opus-4-7  # optional override; default: claude-opus-4-7
 # CHART_LLM_MODEL=claude-haiku-4-5
+
+# Bedrock (used when LLM_PROVIDER=bedrock) — Anthropic models on AWS Bedrock.
+# Auth uses the standard AWS credential chain (env vars, ~/.aws/credentials,
+# IAM role) by default. Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY below
+# to override with explicit keys. AWS_SESSION_TOKEN is optional (STS).
+AWS_REGION=us-west-2
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_SESSION_TOKEN=
+# Model IDs on Bedrock differ from native Anthropic IDs — use the full
+# inference-profile ID (e.g. "us.anthropic.claude-sonnet-4-5-20250929-v1:0").
+# LLM_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+# CHART_LLM_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
 
 # Database (pluggable)
 # PostgreSQL (production):

--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ LLM_MODEL=claude-opus-4-7          # upgrade just the agent
 QUALITY_LLM_MODEL=claude-sonnet-4-6 # or use a stronger model for quality scoring
 ```
 
+### AWS Bedrock
+
+Anthropic models can also be run via AWS Bedrock. Set `LLM_PROVIDER=bedrock` and use the Bedrock inference-profile model IDs (e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0`). Auth falls back to the standard AWS credential chain (env vars, `~/.aws/credentials`, IAM role); to override, set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and optionally `AWS_SESSION_TOKEN` for STS). `AWS_REGION` defaults to `us-west-2`.
+
+```bash
+LLM_PROVIDER=bedrock
+AWS_REGION=us-west-2
+LLM_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+```
+
 ---
 
 ## Database

--- a/backend/src/analytics_agent/agent/llm.py
+++ b/backend/src/analytics_agent/agent/llm.py
@@ -37,11 +37,25 @@ def _make_google(model: str, streaming: bool) -> BaseChatModel:
     return ChatGoogleGenerativeAI(**kwargs)
 
 
+def _make_bedrock(model: str, streaming: bool) -> BaseChatModel:
+    from langchain_aws import ChatBedrockConverse
+
+    kwargs: dict = {"model": model, "region_name": settings.aws_region}
+    # Explicit creds override the default AWS credential chain when provided.
+    if settings.aws_access_key_id and settings.aws_secret_access_key:
+        kwargs["aws_access_key_id"] = SecretStr(settings.aws_access_key_id)
+        kwargs["aws_secret_access_key"] = SecretStr(settings.aws_secret_access_key)
+        if settings.aws_session_token:
+            kwargs["aws_session_token"] = SecretStr(settings.aws_session_token)
+    return ChatBedrockConverse(**kwargs)
+
+
 # Registry — adding a provider means adding one entry here.
 _FACTORIES: dict[str, Callable[[str, bool], BaseChatModel]] = {
     "anthropic": _make_anthropic,
     "openai": _make_openai,
     "google": _make_google,
+    "bedrock": _make_bedrock,
 }
 
 

--- a/backend/src/analytics_agent/api/settings.py
+++ b/backend/src/analytics_agent/api/settings.py
@@ -1698,12 +1698,21 @@ class LlmSettingsResponse(BaseModel):
     provider: str = "anthropic"
     model: str = ""
     has_key: bool = False
+    # Bedrock only — signals that explicit AWS keys are stored. Callers use this
+    # to decide whether to show a masked-placeholder in the settings UI.
+    has_aws_keys: bool = False
+    aws_region: str = ""
 
 
 class UpdateLlmSettingsRequest(BaseModel):
     provider: str = "anthropic"
     api_key: str = ""
     model: str = ""
+    # Bedrock-only fields. Leave blank to use the default AWS credential chain.
+    aws_region: str = ""
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    aws_session_token: str = ""
 
 
 @router.get("/llm", response_model=LlmSettingsResponse)
@@ -1718,14 +1727,32 @@ async def get_llm_settings() -> LlmSettingsResponse:
 
     provider = cfg.llm_provider
     key_attr = PROVIDER_KEY_ATTR.get(provider, "")
-    has_key = bool(getattr(cfg, key_attr, "")) if key_attr else False
-    return LlmSettingsResponse(provider=provider, model=cfg.get_llm_model(), has_key=has_key)
+    has_aws_keys = bool(cfg.aws_access_key_id and cfg.aws_secret_access_key)
+    if provider == "bedrock":
+        # Bedrock has no single "API key". It's considered configured if the
+        # provider is explicitly selected — auth falls back to the AWS credential
+        # chain (env vars, ~/.aws/credentials, IAM role) at call time.
+        has_key = True
+    else:
+        has_key = bool(getattr(cfg, key_attr, "")) if key_attr else False
+    return LlmSettingsResponse(
+        provider=provider,
+        model=cfg.get_llm_model(),
+        has_key=has_key,
+        has_aws_keys=has_aws_keys,
+        aws_region=cfg.aws_region,
+    )
 
 
 class TestLlmKeyRequest(BaseModel):
     provider: str = "anthropic"
-    api_key: str
+    api_key: str = ""
     model: str = ""
+    # Bedrock-only — leave blank to use the default AWS credential chain.
+    aws_region: str = ""
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    aws_session_token: str = ""
 
 
 class TestLlmKeyResponse(BaseModel):
@@ -1762,6 +1789,28 @@ async def test_llm_key(body: TestLlmKeyRequest) -> TestLlmKeyResponse:
             llm = ChatGoogleGenerativeAI(  # type: ignore[assignment]
                 model=model, google_api_key=SecretStr(body.api_key), max_output_tokens=1
             )
+        elif body.provider == "bedrock":
+            from langchain_aws import ChatBedrockConverse
+
+            # Fall back to whatever is already in settings/env when the request
+            # omits a field — lets the user verify "existing" creds without
+            # retyping them.
+            from analytics_agent.config import settings as _cfg
+
+            bk_kwargs: dict = {
+                "model": model,
+                "region_name": body.aws_region or _cfg.aws_region or "us-west-2",
+                "max_tokens": 1,
+            }
+            akid = body.aws_access_key_id or _cfg.aws_access_key_id
+            asak = body.aws_secret_access_key or _cfg.aws_secret_access_key
+            tok = body.aws_session_token or _cfg.aws_session_token
+            if akid and asak:
+                bk_kwargs["aws_access_key_id"] = SecretStr(akid)
+                bk_kwargs["aws_secret_access_key"] = SecretStr(asak)
+                if tok:
+                    bk_kwargs["aws_session_token"] = SecretStr(tok)
+            llm = ChatBedrockConverse(**bk_kwargs)
         else:
             from langchain_openai import ChatOpenAI
 
@@ -1824,6 +1873,15 @@ async def update_llm_settings(
         new_cfg["model"] = body.model
     if body.api_key:
         new_cfg["api_key"] = _fernet_encrypt(body.api_key)
+    # Bedrock AWS fields. Region stored plaintext (non-secret); keys encrypted.
+    if body.aws_region:
+        new_cfg["aws_region"] = body.aws_region
+    if body.aws_access_key_id:
+        new_cfg["aws_access_key_id"] = _fernet_encrypt(body.aws_access_key_id)
+    if body.aws_secret_access_key:
+        new_cfg["aws_secret_access_key"] = _fernet_encrypt(body.aws_secret_access_key)
+    if body.aws_session_token:
+        new_cfg["aws_session_token"] = _fernet_encrypt(body.aws_session_token)
 
     await repo.set(_KEY_LLM_CONFIG, orjson.dumps(new_cfg).decode())
 
@@ -1843,6 +1901,19 @@ async def update_llm_settings(
             os.environ[env_var] = body.api_key
         if attr:
             setattr(cfg, attr, body.api_key)
+    # Bedrock fields flow into both env and singleton so langchain-aws picks them up.
+    if body.aws_region:
+        os.environ["AWS_REGION"] = body.aws_region
+        cfg.aws_region = body.aws_region
+    if body.aws_access_key_id:
+        os.environ["AWS_ACCESS_KEY_ID"] = body.aws_access_key_id
+        cfg.aws_access_key_id = body.aws_access_key_id
+    if body.aws_secret_access_key:
+        os.environ["AWS_SECRET_ACCESS_KEY"] = body.aws_secret_access_key
+        cfg.aws_secret_access_key = body.aws_secret_access_key
+    if body.aws_session_token:
+        os.environ["AWS_SESSION_TOKEN"] = body.aws_session_token
+        cfg.aws_session_token = body.aws_session_token
 
     return {"success": True, "message": "LLM settings saved."}
 

--- a/backend/src/analytics_agent/config.py
+++ b/backend/src/analytics_agent/config.py
@@ -115,6 +115,12 @@ PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
         "quality": "gemini-1.5-flash",
         "delight": "gemini-1.5-flash",
     },
+    "bedrock": {
+        "main": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "chart": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "quality": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "delight": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    },
 }
 
 # Env var name that holds the API key for each provider.
@@ -144,6 +150,13 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     google_api_key: str = ""
+    # Bedrock — uses the standard AWS credential chain by default (env vars,
+    # ~/.aws/credentials, IAM role). Set the explicit *_key_id/*_access_key
+    # settings to override.
+    aws_region: str = "us-west-2"
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    aws_session_token: str = ""
     # Model IDs — override any tier independently via env vars.
     # Unset tiers fall back to PROVIDER_DEFAULTS[llm_provider][tier].
     llm_model: str = ""  # LLM_MODEL         — main analysis agent

--- a/backend/src/analytics_agent/main.py
+++ b/backend/src/analytics_agent/main.py
@@ -387,6 +387,32 @@ async def _load_llm_config_from_db() -> None:
         settings.llm_model = model
         os.environ["LLM_MODEL"] = model
 
+    # Bedrock AWS fields. Region is plaintext; keys are fernet-encrypted.
+    # Env var always wins (explicit user override), same pattern as api_key.
+    aws_region = cfg_data.get("aws_region", "")
+    if aws_region and not os.environ.get("AWS_REGION"):
+        settings.aws_region = aws_region
+        os.environ["AWS_REGION"] = aws_region
+
+    for db_key, env_var, attr in [
+        ("aws_access_key_id", "AWS_ACCESS_KEY_ID", "aws_access_key_id"),
+        ("aws_secret_access_key", "AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
+        ("aws_session_token", "AWS_SESSION_TOKEN", "aws_session_token"),
+    ]:
+        encrypted = cfg_data.get(db_key, "")
+        if not encrypted or os.environ.get(env_var):
+            continue
+        try:
+            from analytics_agent.api.settings import _fernet_decrypt
+
+            value = _fernet_decrypt(encrypted)
+        except Exception as exc:
+            logging.getLogger(__name__).error("Failed to decrypt %s from DB: %s", db_key, exc)
+            continue
+        if value:
+            os.environ[env_var] = value
+            setattr(settings, attr, value)
+
 
 def _run_migrations() -> None:
     """Run Alembic migrations synchronously (Alembic is a sync tool)."""

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -242,6 +242,17 @@ export interface LlmSettings {
   provider: string;
   model: string;
   has_key: boolean;
+  has_aws_keys?: boolean;
+  aws_region?: string;
+}
+
+/** Bedrock-only credential fields. All optional — leave blank to use the
+ *  default AWS credential chain (env vars, ~/.aws, IAM role). */
+export interface BedrockCredentials {
+  aws_region?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_session_token?: string;
 }
 
 export async function getLlmSettings(): Promise<LlmSettings> {
@@ -254,11 +265,19 @@ export async function testLlmKey(s: {
   provider: string;
   api_key: string;
   model?: string;
-}): Promise<{ ok: boolean; message: string }> {
+} & BedrockCredentials): Promise<{ ok: boolean; message: string }> {
   const res = await fetch("/api/settings/llm/test", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ provider: s.provider, api_key: s.api_key, model: s.model ?? "" }),
+    body: JSON.stringify({
+      provider: s.provider,
+      api_key: s.api_key,
+      model: s.model ?? "",
+      aws_region: s.aws_region ?? "",
+      aws_access_key_id: s.aws_access_key_id ?? "",
+      aws_secret_access_key: s.aws_secret_access_key ?? "",
+      aws_session_token: s.aws_session_token ?? "",
+    }),
   });
   if (!res.ok) throw new Error("Test request failed");
   return res.json();
@@ -268,11 +287,19 @@ export async function saveLlmSettings(s: {
   provider: string;
   api_key: string;
   model?: string;
-}): Promise<void> {
+} & BedrockCredentials): Promise<void> {
   const res = await fetch("/api/settings/llm", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ provider: s.provider, api_key: s.api_key, model: s.model ?? "" }),
+    body: JSON.stringify({
+      provider: s.provider,
+      api_key: s.api_key,
+      model: s.model ?? "",
+      aws_region: s.aws_region ?? "",
+      aws_access_key_id: s.aws_access_key_id ?? "",
+      aws_secret_access_key: s.aws_secret_access_key ?? "",
+      aws_session_token: s.aws_session_token ?? "",
+    }),
   });
   if (!res.ok) throw new Error("Failed to save LLM settings");
 }

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -3,7 +3,7 @@ import { Check, Eye, EyeOff, Loader2, X } from "lucide-react";
 import { saveDisplaySettings, saveLlmSettings, testLlmKey } from "@/api/settings";
 import { useDisplayStore } from "@/store/display";
 
-type Provider = "anthropic" | "openai" | "google";
+type Provider = "anthropic" | "openai" | "google" | "bedrock";
 
 interface WizardProps {
   onComplete: () => void;
@@ -11,6 +11,8 @@ interface WizardProps {
 }
 
 // ─── Model options ─────────────────────────────────────────────────────────────
+
+const CUSTOM_MODEL_VALUE = "__custom__";
 
 const MODELS: Record<Provider, { value: string; label: string; note: string }[]> = {
   anthropic: [
@@ -28,7 +30,22 @@ const MODELS: Record<Provider, { value: string; label: string; note: string }[]>
     { value: "gemini-1.5-pro",     label: "Gemini 1.5 Pro",     note: "Most capable"},
     { value: "gemini-1.5-flash",   label: "Gemini 1.5 Flash",   note: "Fastest"     },
   ],
+  bedrock: [
+    { value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Claude Sonnet 4.5 (Bedrock)", note: "Recommended" },
+    { value: "us.anthropic.claude-haiku-4-5-20251001-v1:0",  label: "Claude Haiku 4.5 (Bedrock)",  note: "Fastest"     },
+    { value: CUSTOM_MODEL_VALUE,                              label: "Custom model ID",            note: "Enter your own" },
+  ],
 };
+
+function defaultModelFor(p: Provider): string {
+  return p === "bedrock" ? MODELS[p][0].value : MODELS[p][1].value;
+}
+
+const providerLabel = (p: Provider) =>
+  p === "anthropic" ? "Anthropic"
+    : p === "openai" ? "OpenAI"
+    : p === "google" ? "Google"
+    : "AWS Bedrock";
 
 // ─── Step 1 — warm inline sentence ────────────────────────────────────────────
 
@@ -132,60 +149,61 @@ function Step1Name({ value, onChange, onSubmit }: { value: string; onChange: (v:
 
 export type KeyStatus = { state: "idle" } | { state: "testing" } | { state: "ok"; msg: string } | { state: "fail"; msg: string };
 
-function Step2Model({
-  provider, onProvider,
-  model,    onModel,
-  apiKey,   onApiKey,
-  keyStatus, onKeyBlur,
-}: {
+interface Step2Props {
   provider: Provider;   onProvider: (p: Provider) => void;
   model: string;        onModel: (m: string) => void;
+  customModel: string;  onCustomModel: (m: string) => void;
   apiKey: string;       onApiKey: (k: string) => void;
-  keyStatus: KeyStatus; onKeyBlur: () => void;
-}) {
-  const [showKey, setShowKey] = useState(false);
-  const models = MODELS[provider];
+  awsRegion: string;    onAwsRegion: (v: string) => void;
+  awsAccessKey: string; onAwsAccessKey: (v: string) => void;
+  awsSecret: string;    onAwsSecret: (v: string) => void;
+  awsSessionToken: string; onAwsSessionToken: (v: string) => void;
+  keyStatus: KeyStatus; onVerify: () => void;
+}
 
-  const handleProvider = (p: Provider) => {
-    onProvider(p);
-    onModel(MODELS[p][1].value);
+function Step2Model(p: Step2Props) {
+  const [showKey, setShowKey] = useState(false);
+  const [showAwsSecret, setShowAwsSecret] = useState(false);
+  const models = MODELS[p.provider];
+  const isCustom = p.model === CUSTOM_MODEL_VALUE;
+
+  const handleProvider = (next: Provider) => {
+    p.onProvider(next);
+    p.onModel(defaultModelFor(next));
   };
 
   return (
     <div className="flex flex-col justify-center h-full max-w-lg">
-      {/* Big intro sentence */}
       <div className="text-[2rem] font-light tracking-[-0.02em] leading-[1.3] text-foreground mb-10">
         Before we can get started, I'll need<br />
         to pick a model to think with.
       </div>
 
-      {/* Provider segmented control */}
-      <div className="flex rounded-xl border border-border p-1 gap-1 mb-7 w-fit">
-        {(["anthropic", "openai", "google"] as Provider[]).map((p) => (
+      <div className="flex flex-wrap rounded-xl border border-border p-1 gap-1 mb-7 w-fit">
+        {(["anthropic", "openai", "google", "bedrock"] as Provider[]).map((name) => (
           <button
-            key={p}
+            key={name}
             type="button"
-            onClick={() => handleProvider(p)}
+            onClick={() => handleProvider(name)}
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-all duration-150
-              ${provider === p
+              ${p.provider === name
                 ? "bg-primary text-primary-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground"
               }`}
           >
-            {p === "anthropic" ? "Anthropic" : p === "openai" ? "OpenAI" : "Google"}
+            {providerLabel(name)}
           </button>
         ))}
       </div>
 
-      {/* Model radio list */}
-      <div className="space-y-1 mb-8">
+      <div className="space-y-1 mb-4">
         {models.map((m) => {
-          const active = model === m.value;
+          const active = p.model === m.value;
           return (
             <button
               key={m.value}
               type="button"
-              onClick={() => onModel(m.value)}
+              onClick={() => p.onModel(m.value)}
               className={`w-full flex items-center gap-4 px-4 py-3 rounded-xl text-left
                 transition-all duration-150 border
                 ${active
@@ -193,81 +211,155 @@ function Step2Model({
                   : "border-transparent hover:border-border hover:bg-muted/40"
                 }`}
             >
-              {/* Radio circle */}
               <div className={`w-5 h-5 rounded-full border-2 flex-shrink-0 flex items-center justify-center
                 transition-all duration-150
                 ${active ? "border-primary bg-primary" : "border-border"}`}>
                 {active && <div className="w-2 h-2 rounded-full bg-white" />}
               </div>
-
               <div className="flex-1 min-w-0">
                 <span className={`text-sm font-medium ${active ? "text-foreground" : "text-foreground/80"}`}>
                   {m.label}
                 </span>
               </div>
-
-              <span className={`text-xs flex-shrink-0
-                ${active ? "text-primary/70" : "text-muted-foreground/50"}`}>
+              <span className={`text-xs flex-shrink-0 ${active ? "text-primary/70" : "text-muted-foreground/50"}`}>
                 {m.note}
               </span>
             </button>
           );
         })}
       </div>
+      {isCustom && (
+        <input
+          type="text"
+          value={p.customModel}
+          onChange={(e) => p.onCustomModel(e.target.value)}
+          placeholder={p.provider === "bedrock"
+            ? "us.anthropic.claude-opus-4-5-20251001-v1:0"
+            : "model-id"}
+          className="w-full mb-6 bg-background border border-border rounded-xl px-4 py-3
+                     text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                     focus:border-primary/50 placeholder:text-muted-foreground/30"
+        />
+      )}
+      {!isCustom && <div className="mb-6" />}
 
-      {/* API key */}
-      <div className="space-y-2">
-        <label className="text-sm font-medium text-foreground">
-          API key <span className="text-primary">*</span>
-        </label>
-        <div className="relative">
+      {/* Credentials — either a single API key field OR AWS fields for Bedrock. */}
+      {p.provider === "bedrock" ? (
+        <div className="space-y-3">
+          <div>
+            <label className="text-sm font-medium text-foreground">AWS credentials</label>
+            <p className="text-xs text-muted-foreground/60 mt-1">
+              Leave keys blank to use the system AWS credential chain (env vars,
+              <span className="font-mono"> ~/.aws</span>, IAM role).
+            </p>
+          </div>
           <input
-            type={showKey ? "text" : "password"}
-            value={apiKey}
-            onChange={(e) => onApiKey(e.target.value)}
-            onBlur={onKeyBlur}
-            placeholder={provider === "anthropic" ? "sk-ant-api03-…" : provider === "google" ? "AIza…" : "sk-proj-…"}
-            className={`w-full bg-background border rounded-xl px-4 py-3 text-sm font-mono
-              focus:outline-none focus:ring-2 focus:ring-primary/25
-              placeholder:text-muted-foreground/30 transition-all pr-11
-              ${keyStatus.state === "ok"   ? "border-emerald-500/50 focus:border-emerald-500/60"
-              : keyStatus.state === "fail" ? "border-red-400/50 focus:border-red-400/60"
-              : "border-border focus:border-primary/50"}`}
+            type="text"
+            value={p.awsRegion}
+            onChange={(e) => p.onAwsRegion(e.target.value)}
+            placeholder="us-west-2"
+            className="w-full bg-background border border-border rounded-xl px-4 py-2.5
+                       text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                       focus:border-primary/50"
+          />
+          <input
+            type="text"
+            value={p.awsAccessKey}
+            onChange={(e) => p.onAwsAccessKey(e.target.value)}
+            placeholder="Access key ID (AKIA…, optional)"
+            className="w-full bg-background border border-border rounded-xl px-4 py-2.5
+                       text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                       focus:border-primary/50 placeholder:text-muted-foreground/30"
+          />
+          <div className="relative">
+            <input
+              type={showAwsSecret ? "text" : "password"}
+              value={p.awsSecret}
+              onChange={(e) => p.onAwsSecret(e.target.value)}
+              placeholder="Secret access key (optional)"
+              className="w-full bg-background border border-border rounded-xl px-4 py-2.5
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50 placeholder:text-muted-foreground/30 pr-11"
+            />
+            <button
+              type="button"
+              onClick={() => setShowAwsSecret((v) => !v)}
+              className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40 hover:text-muted-foreground"
+            >
+              {showAwsSecret ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
+          <input
+            type="password"
+            value={p.awsSessionToken}
+            onChange={(e) => p.onAwsSessionToken(e.target.value)}
+            placeholder="Session token (optional, for STS)"
+            className="w-full bg-background border border-border rounded-xl px-4 py-2.5
+                       text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                       focus:border-primary/50 placeholder:text-muted-foreground/30"
           />
           <button
             type="button"
-            onClick={() => setShowKey(v => !v)}
-            className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40
-                       hover:text-muted-foreground transition-colors"
+            onClick={p.onVerify}
+            disabled={p.keyStatus.state === "testing"}
+            className="text-sm px-4 py-2 rounded-lg border border-border
+                       hover:bg-muted/50 transition-colors disabled:opacity-40"
           >
-            {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            {p.keyStatus.state === "testing" ? "Verifying…" : "Verify credentials"}
           </button>
         </div>
+      ) : (
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-foreground">
+            API key <span className="text-primary">*</span>
+          </label>
+          <div className="relative">
+            <input
+              type={showKey ? "text" : "password"}
+              value={p.apiKey}
+              onChange={(e) => p.onApiKey(e.target.value)}
+              onBlur={p.onVerify}
+              placeholder={p.provider === "anthropic" ? "sk-ant-api03-…" : p.provider === "google" ? "AIza…" : "sk-proj-…"}
+              className={`w-full bg-background border rounded-xl px-4 py-3 text-sm font-mono
+                focus:outline-none focus:ring-2 focus:ring-primary/25
+                placeholder:text-muted-foreground/30 transition-all pr-11
+                ${p.keyStatus.state === "ok"   ? "border-emerald-500/50 focus:border-emerald-500/60"
+                : p.keyStatus.state === "fail" ? "border-red-400/50 focus:border-red-400/60"
+                : "border-border focus:border-primary/50"}`}
+            />
+            <button
+              type="button"
+              onClick={() => setShowKey((v) => !v)}
+              className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40
+                         hover:text-muted-foreground transition-colors"
+            >
+              {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
+        </div>
+      )}
 
-        {/* Verification status */}
-        {keyStatus.state === "testing" && (
+      <div className="mt-2 min-h-[1.25rem]">
+        {p.keyStatus.state === "testing" && (
           <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Loader2 className="w-3 h-3 animate-spin" />
-            Verifying key…
+            <Loader2 className="w-3 h-3 animate-spin" /> Verifying…
           </p>
         )}
-        {keyStatus.state === "ok" && (
+        {p.keyStatus.state === "ok" && (
           <p className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
-            <Check className="w-3 h-3" strokeWidth={3} />
-            {keyStatus.msg}
+            <Check className="w-3 h-3" strokeWidth={3} /> {p.keyStatus.msg}
           </p>
         )}
-        {keyStatus.state === "fail" && (
+        {p.keyStatus.state === "fail" && (
           <p className="flex items-center gap-1.5 text-xs text-red-500">
-            <X className="w-3 h-3" strokeWidth={3} />
-            {keyStatus.msg}
+            <X className="w-3 h-3" strokeWidth={3} /> {p.keyStatus.msg}
           </p>
         )}
-        {keyStatus.state === "idle" && (
+        {p.keyStatus.state === "idle" && p.provider !== "bedrock" && (
           <p className="text-xs text-muted-foreground/50">
-            {provider === "anthropic"
+            {p.provider === "anthropic"
               ? "console.anthropic.com/settings/api-keys"
-              : provider === "google"
+              : p.provider === "google"
               ? "aistudio.google.com/app/apikey"
               : "platform.openai.com/api-keys"}
           </p>
@@ -315,12 +407,17 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
 
   const [agentName, setAgentName] = useState("");
   const [provider, setProvider] = useState<Provider>("anthropic");
-  const [model, setModel] = useState(MODELS.anthropic[1].value);
+  const [model, setModel] = useState(defaultModelFor("anthropic"));
+  const [customModel, setCustomModel] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [awsRegion, setAwsRegion] = useState("us-west-2");
+  const [awsAccessKey, setAwsAccessKey] = useState("");
+  const [awsSecret, setAwsSecret] = useState("");
+  const [awsSessionToken, setAwsSessionToken] = useState("");
   const [keyStatus, setKeyStatus] = useState<KeyStatus>({ state: "idle" });
 
-  // Reset verification whenever the key or provider changes
-  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, provider]);
+  // Reset verification whenever any credential field changes.
+  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, provider, awsAccessKey, awsSecret, awsRegion, awsSessionToken, customModel]);
 
   const [step, setStep] = useState(0);
   const [animKey, setAnimKey] = useState(0);
@@ -328,7 +425,17 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
   const [error, setError] = useState<string | null>(null);
 
   const displayName = agentName.trim() || "Analytics Agent";
-  const canContinue = step === 0 ? agentName.trim().length > 0 : apiKey.trim().length > 0 && keyStatus.state !== "fail";
+  const isCustomModel = model === CUSTOM_MODEL_VALUE;
+  const effectiveModel = isCustomModel ? customModel.trim() : model;
+
+  // Step 2 advance rules:
+  //  - Bedrock: allow as long as we have a model and verification didn't fail
+  //    (empty AWS fields are valid — means "use default credential chain").
+  //  - Others: require an API key that isn't known-bad.
+  const canAdvanceStep2 = provider === "bedrock"
+    ? !!effectiveModel && keyStatus.state !== "fail"
+    : apiKey.trim().length > 0 && keyStatus.state !== "fail";
+  const canContinue = step === 0 ? agentName.trim().length > 0 : canAdvanceStep2;
 
   const navigate = (next: number) => {
     setError(null);
@@ -336,19 +443,26 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
     setAnimKey(k => k + 1);
   };
 
-  // Shared test runner — used by onBlur AND by handleContinue
   const runKeyTest = async (): Promise<boolean> => {
-    if (!apiKey.trim()) return false;
+    if (provider !== "bedrock" && !apiKey.trim()) return false;
     setKeyStatus({ state: "testing" });
     try {
-      const result = await testLlmKey({ provider, api_key: apiKey.trim(), model });
+      const result = await testLlmKey({
+        provider,
+        api_key: apiKey.trim(),
+        model: effectiveModel,
+        aws_region: awsRegion.trim(),
+        aws_access_key_id: awsAccessKey.trim(),
+        aws_secret_access_key: awsSecret.trim(),
+        aws_session_token: awsSessionToken.trim(),
+      });
       const next: KeyStatus = result.ok
         ? { state: "ok", msg: result.message }
         : { state: "fail", msg: result.message };
       setKeyStatus(next);
       return result.ok;
     } catch {
-      setKeyStatus({ state: "fail", msg: "Can't reach the server to verify key" });
+      setKeyStatus({ state: "fail", msg: "Can't reach the server to verify" });
       return false;
     }
   };
@@ -362,12 +476,23 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
         setDisplay(displayName, "");
         navigate(1);
       } else {
-        // Always verify before saving — covers the case where user never blurred the field
+        if (isCustomModel && !customModel.trim()) {
+          setError("Enter a model ID or pick one from the list.");
+          return;
+        }
         if (keyStatus.state !== "ok") {
           const ok = await runKeyTest();
           if (!ok) return;
         }
-        await saveLlmSettings({ provider, api_key: apiKey.trim(), model });
+        await saveLlmSettings({
+          provider,
+          api_key: apiKey.trim(),
+          model: effectiveModel,
+          aws_region: awsRegion.trim(),
+          aws_access_key_id: awsAccessKey.trim(),
+          aws_secret_access_key: awsSecret.trim(),
+          aws_session_token: awsSessionToken.trim(),
+        });
         onComplete();
       }
     } catch (e) {
@@ -445,8 +570,13 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
             <Step2Model
               provider={provider} onProvider={setProvider}
               model={model}       onModel={setModel}
+              customModel={customModel} onCustomModel={setCustomModel}
               apiKey={apiKey}     onApiKey={setApiKey}
-              keyStatus={keyStatus} onKeyBlur={runKeyTest}
+              awsRegion={awsRegion} onAwsRegion={setAwsRegion}
+              awsAccessKey={awsAccessKey} onAwsAccessKey={setAwsAccessKey}
+              awsSecret={awsSecret} onAwsSecret={setAwsSecret}
+              awsSessionToken={awsSessionToken} onAwsSessionToken={setAwsSessionToken}
+              keyStatus={keyStatus} onVerify={runKeyTest}
             />
           )}
           {error && (

--- a/frontend/src/components/Settings/ModelSection.tsx
+++ b/frontend/src/components/Settings/ModelSection.tsx
@@ -2,7 +2,11 @@ import { useState, useEffect } from "react";
 import { Check, Eye, EyeOff, Loader2, X } from "lucide-react";
 import { getLlmSettings, saveLlmSettings, testLlmKey } from "@/api/settings";
 
-type Provider = "anthropic" | "openai" | "google";
+type Provider = "anthropic" | "openai" | "google" | "bedrock";
+
+// Sentinel value for the "Custom…" radio option on providers (Bedrock) where
+// users commonly need to pin a specific model ID / inference profile.
+const CUSTOM_MODEL_VALUE = "__custom__";
 
 const MODELS: Record<Provider, { value: string; label: string; note: string }[]> = {
   anthropic: [
@@ -20,7 +24,18 @@ const MODELS: Record<Provider, { value: string; label: string; note: string }[]>
     { value: "gemini-1.5-pro",   label: "Gemini 1.5 Pro",   note: "Most capable" },
     { value: "gemini-1.5-flash", label: "Gemini 1.5 Flash", note: "Fastest"      },
   ],
+  bedrock: [
+    { value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Claude Sonnet 4.5 (Bedrock)", note: "Recommended" },
+    { value: "us.anthropic.claude-haiku-4-5-20251001-v1:0",  label: "Claude Haiku 4.5 (Bedrock)",  note: "Fastest"     },
+    { value: CUSTOM_MODEL_VALUE,                              label: "Custom model ID",            note: "Enter your own" },
+  ],
 };
+
+// Pick a sensible default model when switching providers. For Bedrock we pick
+// the first entry (Sonnet); others use index 1 which is the "Recommended" row.
+function defaultModelFor(p: Provider): string {
+  return p === "bedrock" ? MODELS[p][0].value : MODELS[p][1].value;
+}
 
 type KeyStatus =
   | { state: "idle" }
@@ -32,18 +47,32 @@ type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 export function ModelSection() {
   const [provider, setProvider] = useState<Provider>("anthropic");
-  const [model, setModel] = useState(MODELS.anthropic[1].value);
+  const [model, setModel] = useState(defaultModelFor("anthropic"));
+  const [customModel, setCustomModel] = useState("");
   const [apiKey, setApiKey] = useState("");
+  // Bedrock-only credential fields.
+  const [awsRegion, setAwsRegion] = useState("us-west-2");
+  const [awsAccessKey, setAwsAccessKey] = useState("");
+  const [awsSecret, setAwsSecret] = useState("");
+  const [awsSessionToken, setAwsSessionToken] = useState("");
+  const [showSessionToken, setShowSessionToken] = useState(false);
   // Track which provider the saved key belongs to so switching away and back
   // correctly shows/hides the "Key saved" placeholder.
   const [savedProvider, setSavedProvider] = useState<Provider | null>(null);
+  const [hasSavedAwsKeys, setHasSavedAwsKeys] = useState(false);
   const [showKey, setShowKey] = useState(false);
+  const [showAwsSecret, setShowAwsSecret] = useState(false);
   const [keyStatus, setKeyStatus] = useState<KeyStatus>({ state: "idle" });
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const isCustomModel = model === CUSTOM_MODEL_VALUE;
+  const effectiveModel = isCustomModel ? customModel.trim() : model;
   const hasExistingKey = savedProvider === provider && !apiKey;
+  // Bedrock has a separate "configured" concept — either stored keys OR the
+  // user opted into the system credential chain by saving with blank fields.
+  const hasExistingAwsKeys = provider === "bedrock" && hasSavedAwsKeys && !awsAccessKey && !awsSecret;
 
   useEffect(() => {
     getLlmSettings()
@@ -52,46 +81,84 @@ export function ModelSection() {
         const knownProvider = p in MODELS ? p : "anthropic";
         setProvider(knownProvider);
         const knownModels = MODELS[knownProvider].map((m) => m.value);
-        setModel(knownModels.includes(s.model) ? s.model : MODELS[knownProvider][1].value);
+        if (s.model && knownModels.includes(s.model)) {
+          setModel(s.model);
+        } else if (s.model) {
+          // Saved model isn't in the curated list — treat as custom.
+          setModel(CUSTOM_MODEL_VALUE);
+          setCustomModel(s.model);
+        } else {
+          setModel(defaultModelFor(knownProvider));
+        }
         if (s.has_key) setSavedProvider(knownProvider);
+        if (s.aws_region) setAwsRegion(s.aws_region);
+        if (s.has_aws_keys) setHasSavedAwsKeys(true);
       })
       .finally(() => setLoading(false));
   }, []);
 
-  // Reset key status whenever provider or key changes
-  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, provider]);
-  // Reset save status on any change
-  useEffect(() => { setSaveStatus("idle"); setError(null); }, [provider, model, apiKey]);
+  // Reset key status whenever any credential field changes.
+  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, provider, awsAccessKey, awsSecret, awsRegion, awsSessionToken]);
+  // Reset save status on any change.
+  useEffect(() => { setSaveStatus("idle"); setError(null); }, [provider, model, customModel, apiKey, awsAccessKey, awsSecret, awsRegion, awsSessionToken]);
 
   const handleProvider = (p: Provider) => {
     setProvider(p);
-    setModel(MODELS[p][1].value);
+    setModel(defaultModelFor(p));
+    setCustomModel("");
     setApiKey("");
-    // Don't clear savedProvider — switching back should restore the indicator
+    setAwsAccessKey("");
+    setAwsSecret("");
+    setAwsSessionToken("");
+    // Don't clear savedProvider / hasSavedAwsKeys — switching back should restore the indicator.
   };
 
+  const buildTestPayload = () => ({
+    provider,
+    api_key: apiKey.trim(),
+    model: effectiveModel,
+    aws_region: awsRegion.trim(),
+    aws_access_key_id: awsAccessKey.trim(),
+    aws_secret_access_key: awsSecret.trim(),
+    aws_session_token: awsSessionToken.trim(),
+  });
+
   const runKeyTest = async (): Promise<boolean> => {
-    if (!apiKey.trim()) return hasExistingKey; // no new key — existing one is fine
+    // For non-Bedrock: nothing new to test if field is empty; existing key is fine.
+    if (provider !== "bedrock" && !apiKey.trim()) return hasExistingKey;
+    // For Bedrock: always testable — it'll use either the typed creds, the
+    // stored creds, or the default AWS chain.
     setKeyStatus({ state: "testing" });
     try {
-      const result = await testLlmKey({ provider, api_key: apiKey.trim(), model });
+      const result = await testLlmKey(buildTestPayload());
       setKeyStatus(result.ok
         ? { state: "ok", msg: result.message }
         : { state: "fail", msg: result.message }
       );
       return result.ok;
     } catch {
-      setKeyStatus({ state: "fail", msg: "Can't reach the server to verify key" });
+      setKeyStatus({ state: "fail", msg: "Can't reach the server to verify" });
       return false;
     }
   };
 
   const handleSave = async () => {
     setError(null);
+    if (isCustomModel && !customModel.trim()) {
+      setError("Enter a model ID or pick one from the list.");
+      setSaveStatus("error");
+      return;
+    }
     setSaveStatus("saving");
     try {
-      // Verify new key if one was entered
-      if (apiKey.trim()) {
+      if (provider === "bedrock") {
+        // Bedrock: no mandatory field — any save implies "use the default AWS
+        // chain if keys are blank". Still run a test if the user hasn't yet.
+        if (keyStatus.state !== "ok") {
+          const ok = await runKeyTest();
+          if (!ok) { setSaveStatus("error"); return; }
+        }
+      } else if (apiKey.trim()) {
         if (keyStatus.state !== "ok") {
           const ok = await runKeyTest();
           if (!ok) { setSaveStatus("error"); return; }
@@ -101,12 +168,28 @@ export function ModelSection() {
         setSaveStatus("error");
         return;
       }
-      await saveLlmSettings({ provider, api_key: apiKey.trim(), model });
+
+      await saveLlmSettings({
+        provider,
+        api_key: apiKey.trim(),
+        model: effectiveModel,
+        aws_region: awsRegion.trim(),
+        aws_access_key_id: awsAccessKey.trim(),
+        aws_secret_access_key: awsSecret.trim(),
+        aws_session_token: awsSessionToken.trim(),
+      });
+
       if (apiKey.trim()) {
         setSavedProvider(provider);
         setApiKey("");
-        setKeyStatus({ state: "idle" });
       }
+      if (awsAccessKey.trim() && awsSecret.trim()) {
+        setHasSavedAwsKeys(true);
+        setAwsAccessKey("");
+        setAwsSecret("");
+        setAwsSessionToken("");
+      }
+      setKeyStatus({ state: "idle" });
       setSaveStatus("saved");
       setTimeout(() => setSaveStatus("idle"), 2500);
     } catch (e) {
@@ -129,13 +212,16 @@ export function ModelSection() {
     : provider === "google" ? "AIza…"
     : "sk-proj-…";
 
+  const providerLabel = (p: Provider) =>
+    p === "anthropic" ? "Anthropic" : p === "openai" ? "OpenAI" : p === "google" ? "Google" : "AWS Bedrock";
+
   return (
     <div className="max-w-lg space-y-8">
       {/* Provider */}
       <div className="space-y-3">
         <label className="text-sm font-medium text-foreground">Provider</label>
-        <div className="flex rounded-xl border border-border p-1 gap-1 w-fit">
-          {(["anthropic", "openai", "google"] as Provider[]).map((p) => (
+        <div className="flex flex-wrap rounded-xl border border-border p-1 gap-1 w-fit">
+          {(["anthropic", "openai", "google", "bedrock"] as Provider[]).map((p) => (
             <button
               key={p}
               type="button"
@@ -146,7 +232,7 @@ export function ModelSection() {
                   : "text-muted-foreground hover:text-foreground"
                 }`}
             >
-              {p === "anthropic" ? "Anthropic" : p === "openai" ? "OpenAI" : "Google"}
+              {providerLabel(p)}
             </button>
           ))}
         </div>
@@ -188,39 +274,149 @@ export function ModelSection() {
             );
           })}
         </div>
+        {isCustomModel && (
+          <input
+            type="text"
+            value={customModel}
+            onChange={(e) => setCustomModel(e.target.value)}
+            placeholder={provider === "bedrock"
+              ? "us.anthropic.claude-opus-4-5-20251001-v1:0"
+              : "model-id"}
+            className="w-full mt-2 bg-background border border-border rounded-xl px-4 py-3
+                       text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                       focus:border-primary/50 placeholder:text-muted-foreground/30"
+          />
+        )}
       </div>
 
-      {/* API key */}
+      {/* Credentials — either a single API key field OR Bedrock's AWS fields. */}
+      {provider === "bedrock" ? (
+        <div className="space-y-4">
+          <div>
+            <label className="text-sm font-medium text-foreground">AWS credentials</label>
+            <p className="text-xs text-muted-foreground/60 mt-1">
+              Leave access key / secret blank to use the system AWS credential chain
+              (env vars, <span className="font-mono">~/.aws/credentials</span>, IAM role).
+            </p>
+          </div>
+          <div>
+            <label className="text-xs font-medium text-muted-foreground">AWS region</label>
+            <input
+              type="text"
+              value={awsRegion}
+              onChange={(e) => setAwsRegion(e.target.value)}
+              placeholder="us-west-2"
+              className="w-full mt-1 bg-background border border-border rounded-xl px-4 py-2.5
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-muted-foreground">Access key ID</label>
+            <input
+              type="text"
+              value={awsAccessKey}
+              onChange={(e) => setAwsAccessKey(e.target.value)}
+              placeholder={hasExistingAwsKeys ? "Stored — enter a new one to change" : "AKIA… (optional)"}
+              className="w-full mt-1 bg-background border border-border rounded-xl px-4 py-2.5
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50 placeholder:text-muted-foreground/30"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-muted-foreground">Secret access key</label>
+            <div className="relative">
+              <input
+                type={showAwsSecret ? "text" : "password"}
+                value={awsSecret}
+                onChange={(e) => setAwsSecret(e.target.value)}
+                placeholder={hasExistingAwsKeys ? "Stored — enter a new one to change" : "optional"}
+                className="w-full mt-1 bg-background border border-border rounded-xl px-4 py-2.5
+                           text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                           focus:border-primary/50 placeholder:text-muted-foreground/30 pr-11"
+              />
+              <button
+                type="button"
+                onClick={() => setShowAwsSecret((v) => !v)}
+                className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40 hover:text-muted-foreground"
+              >
+                {showAwsSecret ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+          </div>
+          <details className="text-xs" open={showSessionToken || !!awsSessionToken}>
+            <summary
+              className="cursor-pointer text-muted-foreground/60 hover:text-muted-foreground select-none"
+              onClick={() => setShowSessionToken((v) => !v)}
+            >
+              Session token (for temporary STS credentials)
+            </summary>
+            <input
+              type="password"
+              value={awsSessionToken}
+              onChange={(e) => setAwsSessionToken(e.target.value)}
+              placeholder="optional"
+              className="w-full mt-2 bg-background border border-border rounded-xl px-4 py-2.5
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50 placeholder:text-muted-foreground/30"
+            />
+          </details>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-foreground">API key</label>
+          <div className="relative">
+            <input
+              type={showKey ? "text" : "password"}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              onBlur={() => { if (apiKey.trim()) runKeyTest(); }}
+              placeholder={keyPlaceholder}
+              className={`w-full bg-background border rounded-xl px-4 py-3 text-sm font-mono
+                focus:outline-none focus:ring-2 focus:ring-primary/25
+                placeholder:text-muted-foreground/30 transition-all pr-11
+                ${keyStatus.state === "ok"   ? "border-emerald-500/50 focus:border-emerald-500/60"
+                : keyStatus.state === "fail" ? "border-red-400/50 focus:border-red-400/60"
+                : "border-border focus:border-primary/50"}`}
+            />
+            <button
+              type="button"
+              onClick={() => setShowKey((v) => !v)}
+              className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40
+                         hover:text-muted-foreground transition-colors"
+            >
+              {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
+          {keyStatus.state === "idle" && !hasExistingKey && (
+            <p className="text-xs text-muted-foreground/50">
+              {provider === "anthropic"
+                ? "console.anthropic.com/settings/api-keys"
+                : provider === "google"
+                ? "aistudio.google.com/app/apikey"
+                : "platform.openai.com/api-keys"}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Shared verification status + Verify button (Bedrock gets an explicit
+          button since there's no single field to blur off of). */}
       <div className="space-y-2">
-        <label className="text-sm font-medium text-foreground">API key</label>
-        <div className="relative">
-          <input
-            type={showKey ? "text" : "password"}
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            onBlur={() => { if (apiKey.trim()) runKeyTest(); }}
-            placeholder={keyPlaceholder}
-            className={`w-full bg-background border rounded-xl px-4 py-3 text-sm font-mono
-              focus:outline-none focus:ring-2 focus:ring-primary/25
-              placeholder:text-muted-foreground/30 transition-all pr-11
-              ${keyStatus.state === "ok"   ? "border-emerald-500/50 focus:border-emerald-500/60"
-              : keyStatus.state === "fail" ? "border-red-400/50 focus:border-red-400/60"
-              : "border-border focus:border-primary/50"}`}
-          />
+        {provider === "bedrock" && (
           <button
             type="button"
-            onClick={() => setShowKey((v) => !v)}
-            className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40
-                       hover:text-muted-foreground transition-colors"
+            onClick={runKeyTest}
+            disabled={keyStatus.state === "testing"}
+            className="text-sm px-4 py-2 rounded-lg border border-border
+                       hover:bg-muted/50 transition-colors disabled:opacity-40"
           >
-            {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            {keyStatus.state === "testing" ? "Verifying…" : "Verify credentials"}
           </button>
-        </div>
-
-        {/* Key status line */}
+        )}
         {keyStatus.state === "testing" && (
           <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Loader2 className="w-3 h-3 animate-spin" /> Verifying key…
+            <Loader2 className="w-3 h-3 animate-spin" /> Verifying…
           </p>
         )}
         {keyStatus.state === "ok" && (
@@ -233,25 +429,14 @@ export function ModelSection() {
             <X className="w-3 h-3" strokeWidth={3} /> {keyStatus.msg}
           </p>
         )}
-        {keyStatus.state === "idle" && !hasExistingKey && (
-          <p className="text-xs text-muted-foreground/50">
-            {provider === "anthropic"
-              ? "console.anthropic.com/settings/api-keys"
-              : provider === "google"
-              ? "aistudio.google.com/app/apikey"
-              : "platform.openai.com/api-keys"}
-          </p>
-        )}
       </div>
 
-      {/* Error */}
       {error && (
         <p className="text-sm text-red-500 bg-red-500/8 border border-red-500/20 rounded-xl px-4 py-3">
           {error}
         </p>
       )}
 
-      {/* Save button */}
       <button
         type="button"
         onClick={handleSave}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,11 @@ dependencies = [
     "pydantic-settings>=2.5.0",
     "pyyaml>=6.0",
     # Agent
-    "langchain>=0.3.0",
-    "langchain-openai>=0.2.0",
-    "langchain-anthropic>=0.3.0",
-    "langgraph>=0.2.0",
+    "langchain>=1.2.0",
+    "langchain-openai>=1.2.0",
+    "langchain-anthropic>=1.4.0",
+    "langchain-aws>=1.4.0",
+    "langgraph>=1.1.0",
     # DataHub context
     "datahub-agent-context[langchain]>=1.5.0",
     "acryl-datahub[base]>=1.5.0",

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -24,7 +24,9 @@ from analytics_agent.config import (
 
 # ─── PROVIDER_DEFAULTS structure ─────────────────────────────────────────────
 
-EXPECTED_PROVIDERS = {"anthropic", "openai", "google"}
+EXPECTED_PROVIDERS = {"anthropic", "openai", "google", "bedrock"}
+# Providers that authenticate with a single API key (bedrock uses AWS creds instead).
+EXPECTED_API_KEY_PROVIDERS = {"anthropic", "openai", "google"}
 EXPECTED_TIERS = {"main", "chart", "quality", "delight"}
 
 
@@ -45,11 +47,11 @@ def test_provider_defaults_no_empty_values():
 
 
 def test_provider_key_env_covers_all_providers():
-    assert set(PROVIDER_KEY_ENV) == EXPECTED_PROVIDERS
+    assert set(PROVIDER_KEY_ENV) == EXPECTED_API_KEY_PROVIDERS
 
 
 def test_provider_key_attr_covers_all_providers():
-    assert set(PROVIDER_KEY_ATTR) == EXPECTED_PROVIDERS
+    assert set(PROVIDER_KEY_ATTR) == EXPECTED_API_KEY_PROVIDERS
 
 
 def test_provider_key_env_and_attr_consistent():
@@ -141,8 +143,14 @@ def test_get_api_key_empty_when_not_set():
     assert s.get_api_key() == ""
 
 
-def test_get_api_key_unknown_provider_returns_empty():
+def test_get_api_key_bedrock_returns_empty():
+    """Bedrock authenticates via AWS credentials, not a single API key."""
     s = _settings("bedrock")
+    assert s.get_api_key() == ""
+
+
+def test_get_api_key_unknown_provider_returns_empty():
+    s = _settings("mystery-provider")
     assert s.get_api_key() == ""
 
 
@@ -193,7 +201,7 @@ def test_make_llm_google_calls_correct_factory(mock_settings):
 
 @patch("analytics_agent.agent.llm.settings")
 def test_make_llm_unknown_provider_raises(mock_settings):
-    mock_settings.llm_provider = "bedrock"
+    mock_settings.llm_provider = "mystery-provider"
 
     from analytics_agent.agent.llm import _make_llm
 

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ langchain = [
 ]
 
 [[package]]
-name = "datahub-talk-to-data"
+name = "datahub-analytics-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
@@ -728,6 +728,7 @@ dependencies = [
     { name = "keyring" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
+    { name = "langchain-aws" },
     { name = "langchain-google-genai" },
     { name = "langchain-openai" },
     { name = "langgraph" },
@@ -780,11 +781,12 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "keyring", specifier = ">=25.7.0" },
-    { name = "langchain", specifier = ">=0.3.0" },
-    { name = "langchain-anthropic", specifier = ">=0.3.0" },
+    { name = "langchain", specifier = ">=1.2.0" },
+    { name = "langchain-anthropic", specifier = ">=1.4.0" },
+    { name = "langchain-aws", specifier = ">=1.4.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.2" },
-    { name = "langchain-openai", specifier = ">=0.2.0" },
-    { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "langchain-openai", specifier = ">=1.2.0" },
+    { name = "langgraph", specifier = ">=1.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.25.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.46b0" },
@@ -1638,11 +1640,27 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-aws"
+version = "1.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "langchain-core" },
+    { name = "numpy" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/12/9a8c79ea10ab14be116a9adaa8059c9a0d005c0d8f5065180c5b00065a14/langchain_aws-1.4.5.tar.gz", hash = "sha256:9cd1b3940ed6b7c630c091c48d16d158f097b4b3a52d8a28e815832c28a0e977", size = 512811, upload-time = "2026-04-22T16:16:14.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/68a786f2bf4f8b87498ed5e9fb899c94a269b28ce1082d7573f763cd270e/langchain_aws-1.4.5-py3-none-any.whl", hash = "sha256:7571cf0f277b6221ec4ece05afe4ac0281c1dd0e0c9042d8f50260ef024051ec", size = 201481, upload-time = "2026-04-22T16:16:12.645Z" },
+]
+
+[[package]]
 name = "langchain-core"
-version = "1.2.31"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1651,9 +1669,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/5a/7523ff55668a233beef7e909e8e2074a1cc3b620e0bbf0a4ec5f38549b3b/langchain_core-1.2.31.tar.gz", hash = "sha256:aad3ecc9e4dce2dd2bb79526c81b92e5322fd81db7834a031cb80359f2e3ebaa", size = 850756, upload-time = "2026-04-16T13:26:29.241Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/02/668ddf4f1cf963ad691bdbea672a85244e6271eb0a4acfaf662bbd94a3b1/langchain_core-1.2.31-py3-none-any.whl", hash = "sha256:c407193edb99311cc36ec3e4d3667a065bbc4d7d72fbb6e368538b9b134d4033", size = 513264, upload-time = "2026-04-16T13:26:27.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -1687,16 +1705,28 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.14"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/f5/b1a56f703fb90952b07ff9fb5507123a39df1267d62a7f2bb821c5dbb628/langchain_openai-1.1.14.tar.gz", hash = "sha256:71b4262932fabe506ce79c175dbc956cc48f24d81e20b27662df493147750643", size = 1115195, upload-time = "2026-04-16T14:55:24.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/69/0ea9dabd903f750315ab31b8b85dad64f2927e56ddc26252dfe4e4ac2c40/langchain_openai-1.2.0.tar.gz", hash = "sha256:e88edf16002b9ed8e206161181c8a6fb2b3662da23195e0a844d040c3f93ab10", size = 1136352, upload-time = "2026-04-23T00:43:35.31Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/fa/8c33befbc0cf81b21371cc1dab4e7bf94a80b8116194f263a5021ec02529/langchain_openai-1.1.14-py3-none-any.whl", hash = "sha256:cb525d2011f9813fc15a7dcfd4bca5b87badcbcb2c113a7fbe45d1b8a1bbb69c", size = 88705, upload-time = "2026-04-16T14:55:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7b/e8c3beeab0ca042529533072ebee69c66327c1805b3133531b58c422baab/langchain_openai-1.2.0-py3-none-any.whl", hash = "sha256:b3ed14dc48e40890605136f26c6b07e8f293987d95e734ab67cbfa572c523456", size = 98592, upload-time = "2026-04-23T00:43:34.135Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/bb/38b5eaefa41c67735eedd9f9a2568b11c9eb376fa129a5edd7cc3dcde071/langchain_protocol-0.0.11.tar.gz", hash = "sha256:c276e2373b5ac691fc7ac9a72019d55182444ce8e89385c3f7e9f0185d0aace7", size = 6622, upload-time = "2026-04-23T22:13:16.771Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/fa/6a8ecad8472b182f2caf9d83fd89f40fc1590cb96546d90089b7869b7f5e/langchain_protocol-0.0.11-py3-none-any.whl", hash = "sha256:364da1faf6f5d3001413bede792c1a822c0f23ae55d1ce1266ca7d8e80e79011", size = 6778, upload-time = "2026-04-23T22:13:15.712Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds **AWS Bedrock** as a fourth LLM provider (Anthropic models via Bedrock) alongside Anthropic/OpenAI/Google. Uses the standard AWS credential chain by default (env vars, `~/.aws/credentials`, IAM role); explicit `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and optional `AWS_SESSION_TOKEN`) override it.
- Bumps **langchain / langchain-openai / langchain-anthropic → 1.x**, **langgraph → 1.1+**, and adds **langchain-aws 1.4+**.
- UI: Bedrock option in the onboarding wizard and settings, with an AWS credentials form and a custom-model-ID input for Bedrock inference-profile IDs.

## Test plan
- [x] \`uv sync\` resolves cleanly
- [x] Existing providers (anthropic/openai/google) still work end-to-end
- [x] Set \`LLM_PROVIDER=bedrock\` + \`AWS_REGION=us-west-2\` with ambient AWS creds — chat works
- [x] Explicit \`AWS_ACCESS_KEY_ID\`/\`AWS_SECRET_ACCESS_KEY\` override the default chain
- [x] Onboarding wizard: Bedrock tab, region/key fields, "Custom model ID" input
- [x] Settings → Model: switch to Bedrock, save, verify masked key placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)