### PR TITLE
chore: change default ports to 8100 (prod) and 8101 (dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,8 @@ A `justfile` at the repo root covers all common tasks. Install `just` once (`bre
 
 ```bash
 just install          # uv sync + pnpm install
-just start            # build frontend if stale, start backend at :8000
-just port=8001 start  # same on a custom port
+just start            # build frontend if stale, start backend at :8100
+just port=8102 start  # same on a custom port
 just stop             # kill the backend
 just nuke             # wipe the DB (start from scratch / re-trigger wizard)
 just start-remote     # start + print DataHub connection status
@@ -33,8 +33,8 @@ just build            # force frontend rebuild
 ```bash
 uv sync
 cd frontend && pnpm install && pnpm build && cd ..
-uv run uvicorn analytics_agent.main:app --reload --port 8000
-# → http://localhost:8000
+uv run uvicorn analytics_agent.main:app --reload --port 8101
+# → http://localhost:8101
 # The setup wizard handles LLM key + connections on first run.
 # Optional: cp .env.example .env to pre-configure credentials.
 ```
@@ -42,12 +42,12 @@ uv run uvicorn analytics_agent.main:app --reload --port 8000
 ### Two-process mode (frontend hot reload)
 
 ```bash
-# Terminal 1 — backend
-uv run uvicorn analytics_agent.main:app --reload --port 8000
+# Terminal 1 — backend (dev)
+uv run uvicorn analytics_agent.main:app --reload --port 8101
 
 # Terminal 2 — Vite dev server with HMR
 cd frontend && pnpm dev
-# → http://localhost:5173 (proxies /api/* to :8000)
+# → http://localhost:5173 (proxies /api/* to :8101)
 ```
 
 **DataHub credentials**: run `datahub init --sso --host https://your-instance.acryl.io/gms` once. The app reads `~/.datahubenv` automatically; or set `DATAHUB_GMS_URL` + `DATAHUB_GMS_TOKEN` in `config.yaml` / `.env`.
@@ -262,7 +262,7 @@ Edit `prompts/system_prompt.md`. The prompt is loaded at runtime — no restart 
 docker build -f docker/Dockerfile -t analytics-agent .
 
 # Run
-docker run -p 8000:8000 --env-file .env analytics-agent
+docker run -p 8100:8100 --env-file .env analytics-agent
 ```
 
 GitHub Actions (`.github/workflows/docker.yml`) builds and pushes to GHCR on every push to `main` and version tags.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@ When `.env`, `config.yaml`, or Python source changes, the backend needs a restar
 ```bash
 pkill -f "analytics_agent.main"; sleep 2
 set -a && source .env && set +a
-nohup uv run uvicorn analytics_agent.main:app --port 8000 > /tmp/analytics_agent.log 2>&1 &
-sleep 5 && curl -s http://localhost:8000/api/engines
+nohup uv run uvicorn analytics_agent.main:app --port 8100 > /tmp/analytics_agent.log 2>&1 &
+sleep 5 && curl -s http://localhost:8100/api/engines
 ```
 
 The Vite frontend hot-reloads automatically on TypeScript/TSX changes — no restart needed.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bash quickstart.sh
 No `.env` editing required. The script:
 - Starts a local DataHub instance (or connects to an existing one)
 - Loads the Olist e-commerce sample dataset + catalog metadata
-- Builds and launches Analytics Agent at **http://localhost:8000**
+- Builds and launches Analytics Agent at **http://localhost:8100**
 
 Open the browser — a setup wizard walks you through naming your agent, picking a model (Anthropic, OpenAI, or Google), and entering your API key. If you already have one of those keys exported in your shell, it's picked up automatically.
 
@@ -76,12 +76,12 @@ Open the browser — a setup wizard walks you through naming your agent, picking
 git clone https://github.com/datahub-project/analytics-agent.git
 cd analytics-agent
 just install   # uv sync + pnpm install
-just start     # builds frontend, starts backend at :8000
+just start     # builds frontend, starts backend at :8100
 ```
 
-Open **http://localhost:8000** — a setup wizard handles the LLM key and connections on first run.
+Open **http://localhost:8100** — a setup wizard handles the LLM key and connections on first run.
 
-> **Without `just`:** `uv sync && cd frontend && pnpm install && pnpm build && cd .. && uv run uvicorn analytics_agent.main:app --port 8000`
+> **Without `just`:** `uv sync && cd frontend && pnpm install && pnpm build && cd .. && uv run uvicorn analytics_agent.main:app --port 8100`
 
 ### Optional: pre-configure via `.env`
 
@@ -112,10 +112,10 @@ DATAHUB_GMS_TOKEN=eyJhbGci...
 ### Development mode (hot reload)
 
 ```bash
-# Terminal 1 — backend
-uv run uvicorn analytics_agent.main:app --reload --port 8000
+# Terminal 1 — backend (dev)
+uv run uvicorn analytics_agent.main:app --reload --port 8101
 
-# Terminal 2 — frontend HMR (http://localhost:5173)
+# Terminal 2 — frontend HMR (http://localhost:5173, proxies /api/* to :8101)
 cd frontend && pnpm dev
 ```
 
@@ -131,7 +131,7 @@ datahub init --sso --host https://your-instance.acryl.io/gms --token-duration ON
 datahub init --host http://localhost:8080 --username datahub --password datahub
 
 # Verify the connection
-curl -s -X POST http://localhost:8000/api/settings/connections/datahub/test
+curl -s -X POST http://localhost:8100/api/settings/connections/datahub/test
 ```
 
 ---
@@ -216,14 +216,14 @@ The quickstart uses the DataHub MySQL container. For non-quickstart runs, SQLite
 
 ```bash
 docker build -f docker/Dockerfile -t analytics-agent .
-docker run -p 8000:8000 --env-file .env analytics-agent
+docker run -p 8100:8100 --env-file .env analytics-agent
 ```
 
 ### Single process (no Docker)
 
 ```bash
 cd frontend && pnpm build && cd ..
-uv run uvicorn analytics_agent.main:app --host 0.0.0.0 --port 8000
+uv run uvicorn analytics_agent.main:app --host 0.0.0.0 --port 8100
 ```
 
 ---

--- a/backend/src/analytics_agent/api/oauth.py
+++ b/backend/src/analytics_agent/api/oauth.py
@@ -417,7 +417,7 @@ async def initiate_oauth(engine_name: str, session: AsyncSession = Depends(get_s
         raise HTTPException(status_code=400, detail=str(e))
 
     redirect_uri = (
-        app_cfg.get("redirect_uri") or "http://localhost:8000/api/oauth/snowflake/callback"
+        app_cfg.get("redirect_uri") or "http://localhost:8100/api/oauth/snowflake/callback"
     )
     nonce = secrets.token_urlsafe(32)
     state_payload = orjson.dumps(
@@ -581,7 +581,7 @@ async def configure_oauth_app(
     if not body.client_id or not client_secret:
         raise HTTPException(status_code=400, detail="client_id and client_secret are required.")
 
-    redirect_uri = body.redirect_uri or "http://localhost:8000/api/oauth/snowflake/callback"
+    redirect_uri = body.redirect_uri or "http://localhost:8100/api/oauth/snowflake/callback"
     await _save_app_config(repo, engine_name, body.client_id, client_secret, redirect_uri)
     return {"success": True, "message": "OAuth app configuration saved."}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8100:8100"
     env_file: .env
     environment:
       DATABASE_URL: postgresql+asyncpg://talk_to_data:talk_to_data@postgres:5432/talk_to_data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN cp config.yaml.example config.yaml
 # Copy built SPA — FastAPI serves it via static files + SPA fallback
 COPY --from=fe-build /app/frontend/dist ./frontend/dist
 
-EXPOSE 8000
+EXPOSE 8100
 
 CMD ["uv", "run", "uvicorn", "analytics_agent.main:app", \
-     "--host", "0.0.0.0", "--port", "8000"]
+     "--host", "0.0.0.0", "--port", "8100"]

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState, useRef } from "react";
-import type { MessageRecord, UsagePayload } from "@/types";
+import type { MessageRecord, UsagePayload, TurnUsage } from "@/types";
 import { streamMessage, reattachStream } from "@/api/stream";
 import { generateTitle, getConversation, createConversation } from "@/api/conversations";
 import { Download, X } from "lucide-react";
@@ -33,6 +33,7 @@ export function ChatView() {
     setUsageTotals,
     addUsage,
     attachUsageToMessage,
+    setFinalMsgTurnUsage,
     finalizeStreaming,
   } = useConversationsStore();
 
@@ -95,6 +96,7 @@ export function ChatView() {
       try {
         const stream = reattachStream(snapId, controller.signal);
         let result = await stream.next();
+        const reattachTurnUsage: TurnUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0, calls: 0 };
         while (!result.done) {
           // Bail if the user switched away while we were awaiting
           if (activeId !== snapId) {
@@ -115,13 +117,21 @@ export function ChatView() {
           } else if (event.event === "USAGE") {
             const usage = event.payload as unknown as UsagePayload;
             addUsage(usage);
+            reattachTurnUsage.input_tokens += usage.input_tokens || 0;
+            reattachTurnUsage.output_tokens += usage.output_tokens || 0;
+            reattachTurnUsage.total_tokens += usage.total_tokens || 0;
+            reattachTurnUsage.cache_read_tokens += usage.cache_read_tokens || 0;
+            reattachTurnUsage.cache_creation_tokens += usage.cache_creation_tokens || 0;
+            reattachTurnUsage.calls += 1;
             const state = useConversationsStore.getState();
             const targetId =
               state.streamingTextId ??
               [...state.messages].reverse().find((m) => m.role === "assistant" && m.event_type === "TOOL_CALL")?.id ??
               [...state.messages].reverse().find((m) => m.role === "assistant")?.id;
             if (targetId) attachUsageToMessage(targetId, usage);
-          } else if (event.event !== "COMPLETE") {
+          } else if (event.event === "COMPLETE") {
+            if (reattachTurnUsage.calls > 0) setFinalMsgTurnUsage({ ...reattachTurnUsage });
+          } else {
             appendMessage({
               id: event.message_id,
               event_type: event.event,
@@ -209,6 +219,7 @@ export function ChatView() {
       streamAbortRef.current = controller;
       const stream = streamMessage(conversationId, text, controller.signal);
       let result = await stream.next();
+      const sendTurnUsage: TurnUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0, calls: 0 };
       while (!result.done) {
         const event = result.value;
         if (event.event === "TEXT") {
@@ -225,6 +236,12 @@ export function ChatView() {
         } else if (event.event === "USAGE") {
           const usage = event.payload as unknown as UsagePayload;
           addUsage(usage);
+          sendTurnUsage.input_tokens += usage.input_tokens || 0;
+          sendTurnUsage.output_tokens += usage.output_tokens || 0;
+          sendTurnUsage.total_tokens += usage.total_tokens || 0;
+          sendTurnUsage.cache_read_tokens += usage.cache_read_tokens || 0;
+          sendTurnUsage.cache_creation_tokens += usage.cache_creation_tokens || 0;
+          sendTurnUsage.calls += 1;
           // Prefer streaming text (final response), then last TOOL_CALL (iteration cost),
           // then any assistant message. This keeps usage on TOOL_CALL so separators show per-call stats.
           const state = useConversationsStore.getState();
@@ -233,7 +250,9 @@ export function ChatView() {
             [...state.messages].reverse().find((m) => m.role === "assistant" && m.event_type === "TOOL_CALL")?.id ??
             [...state.messages].reverse().find((m) => m.role === "assistant")?.id;
           if (targetId) attachUsageToMessage(targetId, usage);
-        } else if (event.event !== "COMPLETE") {
+        } else if (event.event === "COMPLETE") {
+          if (sendTurnUsage.calls > 0) setFinalMsgTurnUsage({ ...sendTurnUsage });
+        } else {
           appendMessage({
             id: event.message_id,
             event_type: event.event,

--- a/frontend/src/store/conversations.ts
+++ b/frontend/src/store/conversations.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ConversationSummary, Engine, UIMessage, UsagePayload } from "@/types";
+import type { ConversationSummary, Engine, UIMessage, UsagePayload, TurnUsage } from "@/types";
 
 export interface UsageTotals {
   input_tokens: number;
@@ -44,6 +44,7 @@ interface ConversationsState {
   setUsageTotals: (totals: UsageTotals) => void;
   addUsage: (usage: UsagePayload) => void;
   attachUsageToMessage: (messageId: string, usage: UsagePayload) => void;
+  setFinalMsgTurnUsage: (tu: TurnUsage) => void;
   finalizeStreaming: () => void;
 }
 
@@ -127,6 +128,16 @@ export const useConversationsStore = create<ConversationsState>((set) => ({
     set((s) => ({
       messages: s.messages.map((m) => (m.id === messageId ? { ...m, usage } : m)),
     })),
+  setFinalMsgTurnUsage: (tu) =>
+    set((s) => {
+      for (let j = s.messages.length - 1; j >= 0; j--) {
+        const m = s.messages[j];
+        if (m.role === "assistant" && m.event_type === "TEXT" && !m.isThinking) {
+          return { messages: s.messages.map((msg, i) => (i === j ? { ...msg, turnUsage: tu } : msg)) };
+        }
+      }
+      return {};
+    }),
   finalizeStreaming: () =>
     set((s) => ({
       messages: s.messages.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m)),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://localhost:8000",
+        target: "http://localhost:8101",
         changeOrigin: true,
       },
     },

--- a/justfile
+++ b/justfile
@@ -1,7 +1,8 @@
 set dotenv-load := true
 
-port := "8000"
-log  := "/tmp/analytics_agent.log"
+port     := "8100"
+dev_port := "8101"
+log      := "/tmp/analytics_agent.log"
 
 # List available recipes
 default:
@@ -33,14 +34,14 @@ typecheck:
 
 # Start backend (blocks; use 'dev' for background)
 serve:
-    uv run uvicorn analytics_agent.main:app --reload --port {{port}}
+    uv run uvicorn analytics_agent.main:app --reload --port {{dev_port}}
 
 # Build frontend if stale, then start backend in background (with auto-reload on Python changes)
 dev: build-if-stale
     pkill -f "analytics_agent.main" || true
-    nohup uv run uvicorn analytics_agent.main:app --reload --port {{port}} > {{log}} 2>&1 &
-    sleep 3 && curl -s http://localhost:{{port}}/api/engines | head -c 120
-    @echo "\n→ http://localhost:{{port}}  (logs: just logs)"
+    nohup uv run uvicorn analytics_agent.main:app --reload --port {{dev_port}} > {{log}} 2>&1 &
+    sleep 3 && curl -s http://localhost:{{dev_port}}/api/engines | head -c 120
+    @echo "\n→ http://localhost:{{dev_port}}  (logs: just logs)"
 
 # Start backend, rebuilding frontend if stale
 start: build-if-stale
@@ -57,8 +58,8 @@ frontend:
 # Start backend (reload mode) + Vite dev server in parallel
 dev-full:
     pkill -f "analytics_agent.main" || true
-    nohup uv run uvicorn analytics_agent.main:app --reload --port {{port}} > {{log}} 2>&1 &
-    @echo "Backend → http://localhost:{{port}}"
+    nohup uv run uvicorn analytics_agent.main:app --reload --port {{dev_port}} > {{log}} 2>&1 &
+    @echo "Backend → http://localhost:{{dev_port}}"
     cd frontend && pnpm dev
 
 # Kill the backend

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -422,7 +422,7 @@ docker run -d \
     --name analytics-agent-quickstart \
     --env-file .env.quickstart \
     -v "${REPO_ROOT}/config.yaml:/app/config.yaml:ro" \
-    -p 8000:8000 \
+    -p 8100:8100 \
     analytics-agent-quickstart
 
 # Wait for talkster to respond
@@ -430,7 +430,7 @@ go "Waiting for talkster to start..."
 WAIT_SECS=60
 elapsed=0
 printf "    "
-until curl -sf --max-time 2 http://localhost:8000/ &>/dev/null; do
+until curl -sf --max-time 2 http://localhost:8100/ &>/dev/null; do
     if [[ $elapsed -ge $WAIT_SECS ]]; then
         echo ""
         die "Analytics Agent did not start within ${WAIT_SECS}s. Logs: docker logs analytics-agent-quickstart"
@@ -468,7 +468,7 @@ if [[ "${DATAHUB_USE_MCP:-false}" == "true" ]]; then
 }
 EOF
 )
-    _MCP_RESULT=$(curl -sf -X POST http://localhost:8000/api/settings/connections \
+    _MCP_RESULT=$(curl -sf -X POST http://localhost:8100/api/settings/connections \
         -H "Content-Type: application/json" \
         -d "$_MCP_PAYLOAD" 2>/dev/null || echo "failed")
     if echo "$_MCP_RESULT" | grep -q '"success":true'; then
@@ -481,11 +481,11 @@ fi
 echo ""
 echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
 echo -e "${BOLD}║  Analytics Agent is ready!                  ║${NC}"
-echo -e "${BOLD}║  → http://localhost:8000             ║${NC}"
+echo -e "${BOLD}║  → http://localhost:8100             ║${NC}"
 echo -e "${BOLD}╚══════════════════════════════════════╝${NC}"
 echo ""
 if [[ -z "$_LLM_KEY_SOURCE" ]]; then
-    echo -e "${CYAN}  First time?${NC} Open http://localhost:8000 — a setup wizard"
+    echo -e "${CYAN}  First time?${NC} Open http://localhost:8100 — a setup wizard"
     echo -e "  will walk you through picking a model and entering your API key."
     echo ""
 fi

--- a/scripts/datahub_status.py
+++ b/scripts/datahub_status.py
@@ -3,7 +3,7 @@ import json
 import sys
 import urllib.request
 
-port = sys.argv[1] if len(sys.argv) > 1 else "8000"
+port = sys.argv[1] if len(sys.argv) > 1 else "8100"
 try:
     with urllib.request.urlopen(f"http://localhost:{port}/api/settings/connections", timeout=3) as r:
         conns = json.load(r)


### PR DESCRIPTION
## Summary

- Changes default backend port from 8000 → **8100** (prod/Docker) and **8101** (dev/hot-reload)
- Updates all references across `justfile`, `docker/Dockerfile`, `docker-compose.yml`, `quickstart.sh`, `vite.config.ts`, `oauth.py`, `datahub_status.py`, `README.md`, `AGENTS.md`, and `CLAUDE.md`
- `just start` / Docker / quickstart use **8100**; `just serve` / `just dev` / `just dev-full` / Vite proxy use **8101**

## Also includes

- **fix:** token count badge now appears in the AgentWorkBlock header for single-iteration turns. Previously the first USAGE event arrived before any TOOL_CALL was in the store and was silently dropped; the COMPLETE event was also ignored, so `finalMsg.turnUsage` was never set during streaming. Now both streaming loops accumulate USAGE locally and stamp the total onto the final message on COMPLETE.

## Test plan

- [ ] `just start` launches backend on `:8100`
- [ ] `just serve` / `just dev` launch on `:8101`; Vite dev server proxies to `:8101`
- [ ] `bash quickstart.sh` builds and serves at `http://localhost:8100`
- [ ] Docker: `docker run -p 8100:8100 --env-file .env analytics-agent` works
- [ ] After a query, "Worked for Xs · N tool calls" header shows token badge (e.g. `↑12k ↓340`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)