### PR TITLE
fix: quickstart token provisioning and AWS-creds plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ AWS_REGION=us-west-2
 LLM_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 ```
 
-**With `quickstart.sh`:** set `LLM_PROVIDER=bedrock` before running. The script checks that `~/.aws` exists, that your credentials are valid (`aws sts get-caller-identity`), and that Bedrock is accessible in the target region (`aws bedrock list-foundation-models`) — failing fast with actionable messages rather than starting a container that errors on the first query.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ No `.env` editing required. The script:
 - Loads the Olist e-commerce sample dataset + catalog metadata
 - Builds and launches Analytics Agent at **http://localhost:8100**
 
-Open the browser — a setup wizard walks you through naming your agent, picking a model (Anthropic, OpenAI, or Google), and entering your API key. If you already have one of those keys exported in your shell, it's picked up automatically.
+Open the browser — a setup wizard walks you through naming your agent, picking a model (Anthropic, OpenAI, Google, or AWS Bedrock), and entering your API key. If you already have one of those keys exported in your shell, it's picked up automatically.
+
+**Using AWS Bedrock?** Export `LLM_PROVIDER=bedrock` before running the script. The script will verify your AWS credentials and Bedrock access before starting the container, and mount `~/.aws` read-only so boto3 picks up your profiles and SSO cache automatically.
 
 ---
 
@@ -189,6 +191,8 @@ LLM_PROVIDER=bedrock
 AWS_REGION=us-west-2
 LLM_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 ```
+
+**With `quickstart.sh`:** set `LLM_PROVIDER=bedrock` before running. The script checks that `~/.aws` exists, that your credentials are valid (`aws sts get-caller-identity`), and that Bedrock is accessible in the target region (`aws bedrock list-foundation-models`) — failing fast with actionable messages rather than starting a container that errors on the first query.
 
 ---
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -174,12 +174,11 @@ print(gms.get('server',''), gms.get('token',''))
     go "Provisioning local DataHub token via 'datahub init'..."
 
     # Use a temp HOME so datahub init writes to a throwaway dir,
-    # leaving the real ~/.datahubenv completely untouched. Preserve
-    # ASDF_DATA_DIR so asdf shims can still resolve the interpreter.
+    # leaving the real ~/.datahubenv completely untouched.
     local tmp_home
     tmp_home=$(mktemp -d)
 
-    HOME="$tmp_home" ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}" datahub init \
+    HOME="$tmp_home" datahub init \
         --username datahub \
         --password datahub \
         --force \

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -63,7 +63,12 @@ check_cmd python3      "Install Python 3.11+: https://python.org"
 # 2. LLM API key (optional here — the browser wizard handles it if not set)
 # ──────────────────────────────────────────────────────────────────────────────
 _LLM_KEY_SOURCE=""
-if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+# Explicit LLM_PROVIDER=bedrock takes priority — Bedrock has no single env var,
+# so we treat it as opt-in via either LLM_PROVIDER or the presence of ~/.aws.
+if [[ "${LLM_PROVIDER:-}" == "bedrock" && -d "$HOME/.aws" ]]; then
+    _LLM_KEY_SOURCE="bedrock"
+    ok "Bedrock selected — will mount ~/.aws into the container (read-only)"
+elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     _LLM_KEY_SOURCE="anthropic"
     ok "ANTHROPIC_API_KEY found — will be pre-configured in the container"
 elif [[ -n "${OPENAI_API_KEY:-}" ]]; then
@@ -142,18 +147,43 @@ DATAHUB_GMS_TOKEN=""
 # fresh token, extract it, then restore the backup so the user's regular env is
 # untouched.  Can be skipped by pre-setting DATAHUB_GMS_TOKEN in the environment.
 _provision_local_token() {
+    # 1) Honor pre-set env var.
+    if [[ -n "${DATAHUB_GMS_TOKEN:-}" ]]; then
+        ok "Using DATAHUB_GMS_TOKEN from environment"
+        return
+    fi
+
+    # 2) Reuse ~/.datahubenv if it already points at the same GMS host.
+    if [[ -f "$HOME/.datahubenv" ]]; then
+        local existing_host existing_token
+        read -r existing_host existing_token < <(uv run python3 -c "
+import yaml
+with open('$HOME/.datahubenv') as f:
+    cfg = yaml.safe_load(f) or {}
+gms = cfg.get('gms') or {}
+print(gms.get('server',''), gms.get('token',''))
+" 2>/dev/null) || true
+        if [[ "$existing_host" == "$DATAHUB_GMS_URL" && -n "$existing_token" ]]; then
+            DATAHUB_GMS_TOKEN="$existing_token"
+            ok "Reusing token from ~/.datahubenv (host matches ${DATAHUB_GMS_URL})"
+            return
+        fi
+    fi
+
+    # 3) Fall back to minting a fresh token via 'datahub init'.
     go "Provisioning local DataHub token via 'datahub init'..."
 
     # Use a temp HOME so datahub init writes to a throwaway dir,
-    # leaving the real ~/.datahubenv completely untouched.
+    # leaving the real ~/.datahubenv completely untouched. Preserve
+    # ASDF_DATA_DIR so asdf shims can still resolve the interpreter.
     local tmp_home
     tmp_home=$(mktemp -d)
 
-    HOME="$tmp_home" datahub init \
+    HOME="$tmp_home" ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}" datahub init \
         --username datahub \
         --password datahub \
         --force \
-        --host "$DATAHUB_GMS_URL" 2>/dev/null
+        --host "$DATAHUB_GMS_URL" 2>/dev/null || true
 
     local token
     token=$(uv run python3 -c "
@@ -390,6 +420,12 @@ elif [[ "$_LLM_KEY_SOURCE" == "openai" ]]; then
     printf '\nLLM_PROVIDER=openai\nOPENAI_API_KEY=%s\n' "${OPENAI_API_KEY}" >> .env.quickstart
 elif [[ "$_LLM_KEY_SOURCE" == "google" ]]; then
     printf '\nLLM_PROVIDER=google\nGOOGLE_API_KEY=%s\n' "${GOOGLE_API_KEY}" >> .env.quickstart
+elif [[ "$_LLM_KEY_SOURCE" == "bedrock" ]]; then
+    {
+        printf '\nLLM_PROVIDER=bedrock\n'
+        printf 'AWS_REGION=%s\n' "${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
+        [[ -n "${AWS_PROFILE:-}" ]] && printf 'AWS_PROFILE=%s\n' "$AWS_PROFILE"
+    } >> .env.quickstart
 fi
 
 ok ".env.quickstart written (uses host.docker.internal — your .env is untouched)"
@@ -418,10 +454,17 @@ cd "$REPO_ROOT"
 # Stop and remove any previous quickstart container
 docker rm -f analytics-agent-quickstart 2>/dev/null && warn "Removed previous analytics-agent-quickstart container" || true
 
+# Mount ~/.aws read-only when using Bedrock so boto3 can pick up profiles / SSO cache.
+_AWS_MOUNT=()
+if [[ "$_LLM_KEY_SOURCE" == "bedrock" ]]; then
+    _AWS_MOUNT=(-v "$HOME/.aws:/root/.aws:ro")
+fi
+
 docker run -d \
     --name analytics-agent-quickstart \
     --env-file .env.quickstart \
     -v "${REPO_ROOT}/config.yaml:/app/config.yaml:ro" \
+    "${_AWS_MOUNT[@]}" \
     -p 8100:8100 \
     analytics-agent-quickstart
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -65,9 +65,23 @@ check_cmd python3      "Install Python 3.11+: https://python.org"
 _LLM_KEY_SOURCE=""
 # Explicit LLM_PROVIDER=bedrock takes priority — Bedrock has no single env var,
 # so we treat it as opt-in via either LLM_PROVIDER or the presence of ~/.aws.
-if [[ "${LLM_PROVIDER:-}" == "bedrock" && -d "$HOME/.aws" ]]; then
+if [[ "${LLM_PROVIDER:-}" == "bedrock" ]]; then
+    if [[ ! -d "$HOME/.aws" ]]; then
+        die "LLM_PROVIDER=bedrock set but ~/.aws not found. Run 'aws configure' or 'aws sso login' first, then retry."
+    fi
+    go "Verifying AWS credentials..."
+    if ! aws sts get-caller-identity &>/dev/null; then
+        die "AWS credentials not valid or expired. Run 'aws sso login' (or 'aws configure') and retry."
+    fi
+    _aws_region="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
+    go "Verifying Bedrock access in region ${_aws_region}..."
+    if ! aws bedrock list-foundation-models --region "$_aws_region" --output text &>/dev/null; then
+        die "Bedrock not accessible in region ${_aws_region}. Check that:
+  • Bedrock is enabled in your account (console.aws.amazon.com/bedrock)
+  • Your IAM role has bedrock:ListFoundationModels permission"
+    fi
     _LLM_KEY_SOURCE="bedrock"
-    ok "Bedrock selected — will mount ~/.aws into the container (read-only)"
+    ok "Bedrock accessible in ${_aws_region} — will mount ~/.aws into the container (read-only)"
 elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     _LLM_KEY_SOURCE="anthropic"
     ok "ANTHROPIC_API_KEY found — will be pre-configured in the container"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -178,9 +178,19 @@ gms = cfg.get('gms') or {}
 print(gms.get('server',''), gms.get('token',''))
 " 2>/dev/null) || true
         if [[ "$existing_host" == "$DATAHUB_GMS_URL" && -n "$existing_token" ]]; then
-            DATAHUB_GMS_TOKEN="$existing_token"
-            ok "Reusing token from ~/.datahubenv (host matches ${DATAHUB_GMS_URL})"
-            return
+            # Validate the token is actually accepted by this DataHub instance
+            # before trusting it — an expired or stale token would silently
+            # break ingestion later in the script.
+            if curl -sf \
+                -H "Authorization: Bearer $existing_token" \
+                -H "Content-Type: application/json" \
+                -X POST "$DATAHUB_GMS_URL/api/v2/graphql" \
+                -d '{"query":"{ me { corpUser { urn } } }"}' &>/dev/null; then
+                DATAHUB_GMS_TOKEN="$existing_token"
+                ok "Reusing token from ~/.datahubenv (verified against ${DATAHUB_GMS_URL})"
+                return
+            fi
+            # Token rejected — fall through to mint a fresh one.
         fi
     fi
 


### PR DESCRIPTION
## Summary
- Honor a pre-set \`DATAHUB_GMS_TOKEN\` env var and short-circuit \`_provision_local_token\`.
- Reuse an existing \`~/.datahubenv\` token when it already points at the same GMS host — covers the common dev case with zero CLI calls.
- Fall back to \`datahub init\` with \`|| true\` so a failure falls through to the existing warning path instead of aborting under \`set -euo pipefail\`.
- Add Bedrock to the LLM-source detection: triggers on \`LLM_PROVIDER=bedrock\`, mounts \`~/.aws:/root/.aws:ro\` so boto3 picks up profiles / SSO cache from the host, and writes \`LLM_PROVIDER=bedrock\` + \`AWS_REGION\` (default \`us-west-2\`) + \`AWS_PROFILE\` (when set) into \`.env.quickstart\`.

## Test plan
- [x] Run \`./quickstart.sh\` against an existing local DataHub with a valid \`~/.datahubenv\` pointing at \`http://localhost:8080\`: token provisioning short-circuits with "Reusing token from ~/.datahubenv".
- [x] Run with \`DATAHUB_GMS_TOKEN=<token> ./quickstart.sh\`: short-circuits with "Using DATAHUB_GMS_TOKEN from environment".
- [x] Force the fallback (rename \`~/.datahubenv\`, unset env var): \`datahub init\` runs; on failure the script emits the warning and continues instead of aborting.
- [x] Run with \`LLM_PROVIDER=bedrock ./quickstart.sh\` and \`~/.aws\` populated: container starts with the AWS mount and \`LLM_PROVIDER=bedrock\`, \`AWS_REGION\` in \`.env.quickstart\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)