### PR TITLE
feat: add BigQuery query engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,13 @@ SNOWFLAKE_SCHEMA=
 SNOWFLAKE_USER=
 SNOWFLAKE_PASSWORD=
 # SNOWFLAKE_PRIVATE_KEY=   # base64-encoded PEM: base64 -i key.p8 | tr -d '\n'
+
+# BigQuery  (if using bigquery engine)
+# BIGQUERY_PROJECT=
+# BIGQUERY_DATASET=
+# Option 1 — raw service-account JSON as a single-line string:
+# BIGQUERY_CREDENTIALS_JSON='{ "type": "service_account"}'
+# Option 2 — path to a service-account JSON file on disk:
+# BIGQUERY_CREDENTIALS_PATH=./service_account.json
+# Option 3 — service-account JSON already base64-encoded:
+# BIGQUERY_CREDENTIALS_BASE64=ey...

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open the browser — a setup wizard walks you through naming your agent, picking
 | **Multi-turn memory** | Follow-ups like "make it a pie chart" or "filter to Q3" work across turns. |
 | **Collapsible reasoning** | Tool calls and agent thinking are shown but collapsed — visible when you want them, out of the way when you don't. |
 | **4 themes** | DataHub (light/purple), Warm (light/orange), Ocean (dark/blue), Carbon (dark/gray). Switcher in the bottom-left. |
-| **Multiple connections** | Add and manage multiple Snowflake, DuckDB, or SQLAlchemy connections from Settings. Each has its own encrypted credentials. |
+| **Multiple connections** | Add and manage multiple Snowflake, BigQuery, DuckDB, or SQLAlchemy connections from Settings. Each has its own encrypted credentials. |
 
 ---
 
@@ -163,6 +163,80 @@ Generate an RSA key pair, upload the public key to Snowflake, then set `SNOWFLAK
 
 ---
 
+## Connect BigQuery
+
+BigQuery authenticates exclusively via a GCP **service account**. Three credential formats are supported — use whichever fits your deployment:
+
+### Option A — JSON key via environment variable (recommended for containers)
+
+Export the raw service-account JSON (single line, no newlines):
+
+```bash
+export BIGQUERY_CREDENTIALS_JSON='{"type":"service_account","project_id":"my-project",...}'
+```
+
+Or add it to `.env`:
+
+```bash
+BIGQUERY_CREDENTIALS_JSON={"type":"service_account","project_id":"my-project",...}
+```
+
+Then reference the project in `config.yaml`:
+
+```yaml
+# config.yaml
+engines:
+  - type: bigquery
+    name: prod
+    connection:
+      project: "${BIGQUERY_PROJECT}"
+      dataset: "${BIGQUERY_DATASET}"   # optional default dataset
+```
+
+### Option B — Base64-encoded JSON key via `config.yaml`
+
+Encode your key file once:
+
+```bash
+base64 -i my-service-account.json | tr -d '\n'
+```
+
+Then paste the output into `config.yaml`:
+
+```yaml
+engines:
+  - type: bigquery
+    name: prod
+    connection:
+      project: my-gcp-project
+      dataset: my_dataset          # optional
+      credentials_base64: "ey..."
+```
+
+### Option C — Path to a JSON key file
+
+Useful for local development or when the key file is mounted into the container:
+
+```yaml
+engines:
+  - type: bigquery
+    name: prod
+    connection:
+      project: my-gcp-project
+      credentials_path: /secrets/sa-key.json
+```
+
+### Required IAM roles
+
+The service account needs at minimum:
+
+| Role | Purpose |
+|---|---|
+| `roles/bigquery.dataViewer` | Read tables and schemas |
+| `roles/bigquery.jobUser` | Run queries |
+
+---
+
 ## LLM model routing
 
 Four independently configurable model tiers:
@@ -238,7 +312,7 @@ analytics-agent/
 │   ├── context/        # DataHub tool loader (datahub_agent_context)
 │   ├── db/             # SQLAlchemy models + Alembic migrations
 │   │   └── models.py   # Conversation, Message, Integration, Setting
-│   ├── engines/        # Pluggable query engines (Snowflake, DuckDB, SQLAlchemy)
+│   ├── engines/        # Pluggable query engines (Snowflake, BigQuery, DuckDB, SQLAlchemy)
 │   ├── prompts/        # System prompt (system_prompt.md) + chart prompt
 │   └── skills/         # Write-back skills: publish-analysis, save-correction,
 │                       #   improve-context (/improve-context slash command)

--- a/backend/src/analytics_agent/api/settings.py
+++ b/backend/src/analytics_agent/api/settings.py
@@ -198,6 +198,12 @@ _DATAHUB_TOOLS = [
 _KNOWN_TOOLS: dict[str, list[dict]] = {
     "datahub": _DATAHUB_TOOLS,
     "datahub-mcp": _DATAHUB_TOOLS,  # same capabilities, different transport
+    "bigquery": [
+        {"name": "list_tables", "label": "List tables"},
+        {"name": "get_schema", "label": "Table schema"},
+        {"name": "preview_table", "label": "Preview data"},
+        {"name": "execute_sql", "label": "Execute SQL"},
+    ],
     "snowflake": [
         {"name": "list_tables", "label": "List tables"},
         {"name": "get_schema", "label": "Table schema"},
@@ -411,7 +417,49 @@ def _get_engine_connections(disabled: set[str]) -> list[ConnectionStatus]:
         name = cfg.effective_name
         connection = cfg.connection
 
-        if engine_type == "snowflake":
+        if engine_type == "bigquery":
+            project = connection.get("project", "")
+            dataset = connection.get("dataset", "")
+            creds_json = os.environ.get("BIGQUERY_CREDENTIALS_JSON", "") or connection.get(
+                "credentials_json", ""
+            )
+            creds_path = connection.get("credentials_path", "")
+            creds_b64 = connection.get("credentials_base64", "")
+            has_creds = bool(creds_json or creds_path or creds_b64)
+            # ADC is always available as fallback; configured = project is set
+            configured = bool(project)
+            conns.append(
+                ConnectionStatus(
+                    name=name,
+                    type="bigquery",
+                    label=f"BigQuery ({name})",
+                    status="connected" if configured else "unconfigured",
+                    fields=[
+                        ConnectionField(
+                            key="project",
+                            label="GCP Project ID",
+                            value=project,
+                            placeholder="my-gcp-project",
+                        ),
+                        ConnectionField(
+                            key="dataset",
+                            label="Default Dataset",
+                            value=dataset,
+                            placeholder="my_dataset",
+                        ),
+                        ConnectionField(
+                            key="credentials_json",
+                            label="Service Account JSON",
+                            value="(configured)" if has_creds else "",
+                            sensitive=True,
+                            secret_key="credentials_json",
+                            placeholder='{"type":"service_account",...}',
+                        ),
+                    ],
+                    tools=_build_tool_toggles("bigquery", disabled),
+                )
+            )
+        elif engine_type == "snowflake":
             account = connection.get("account", "")
             user = connection.get("user", "")
             warehouse = connection.get("warehouse", "")
@@ -595,6 +643,38 @@ async def list_connections(session: AsyncSession = Depends(get_session)):
                         placeholder="••••••••",
                     )
                 )
+        elif intg.type == "bigquery":
+            project = conn_cfg.get("project", "")
+            dataset = conn_cfg.get("dataset", "")
+            creds_json = os.environ.get("BIGQUERY_CREDENTIALS_JSON", "") or conn_cfg.get(
+                "credentials_json", ""
+            )
+            creds_path = conn_cfg.get("credentials_path", "")
+            creds_b64 = conn_cfg.get("credentials_base64", "")
+            has_creds = bool(creds_json or creds_path or creds_b64)
+            status_str = "connected" if project else "unconfigured"
+            fields = [
+                ConnectionField(
+                    key="project",
+                    label="GCP Project ID",
+                    value=project,
+                    placeholder="my-gcp-project",
+                ),
+                ConnectionField(
+                    key="dataset",
+                    label="Default Dataset",
+                    value=dataset,
+                    placeholder="my_dataset",
+                ),
+                ConnectionField(
+                    key="credentials_json",
+                    label="Service Account JSON",
+                    value="(configured)" if has_creds else "",
+                    sensitive=True,
+                    secret_key="credentials_json",
+                    placeholder='{"type":"service_account",...}',
+                ),
+            ]
         elif intg.type in ("mysql", "sqlalchemy", "postgresql", "sqlite"):
             host = conn_cfg.get("host", "")
             database = conn_cfg.get("database", conn_cfg.get("db", ""))

--- a/backend/src/analytics_agent/engines/bigquery/engine.py
+++ b/backend/src/analytics_agent/engines/bigquery/engine.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import base64
+import datetime
+import logging
+import os
+import uuid
+from decimal import Decimal
+from typing import Any, ClassVar
+
+import orjson
+from langchain_core.tools import BaseTool, tool
+
+from analytics_agent.engines.base import QueryEngine
+
+logger = logging.getLogger(__name__)
+
+
+class BigQueryQueryEngine(QueryEngine):
+    """
+    BigQuery query engine.
+
+    Connection config keys:
+      project            - GCP project ID (required)
+      dataset            - default dataset / schema (optional)
+      credentials_base64 - base64-encoded service-account JSON
+      credentials_path   - path to service-account JSON file on disk
+      credentials_json   - raw service-account JSON string
+      (env var: BIGQUERY_CREDENTIALS_JSON)
+
+    At least one credentials key must be provided.
+    """
+
+    name = "bigquery"
+
+    secret_env_vars: ClassVar[dict[str, str]] = {
+        "credentials_json": "BIGQUERY_CREDENTIALS_JSON",
+    }
+
+    def __init__(self, connection_cfg: dict[str, Any]) -> None:
+        self._cfg = connection_cfg
+        self._engine: Any = None
+
+    @property
+    def datahub_platform(self) -> str:
+        return "bigquery"
+
+    def _resolve_credentials(self) -> str:
+        """
+        Returns service account credentials as a base64 string,
+        ready to be passed to create_engine(credentials_base64=...).
+
+        sqlalchemy-bigquery handles deserialization internally.
+
+        Resolution order:
+          1. credentials_json  (raw JSON from config or BIGQUERY_CREDENTIALS_JSON env var)
+          2. credentials_base64 (already encoded, from config)
+          3. credentials_path  (path to JSON file on disk)
+
+        Raises ValueError if no credentials are found.
+        """
+        # 1. Raw JSON string -> convert to base64
+        raw_json: str | None = self._cfg.get("credentials_json") or os.environ.get(
+            "BIGQUERY_CREDENTIALS_JSON"
+        )
+        if raw_json is not None:
+            return base64.b64encode(raw_json.encode("utf-8")).decode("utf-8")
+
+        b64: str | None = self._cfg.get("credentials_base64")
+        if b64 is not None:
+            return b64
+
+        path: str | None = self._cfg.get("credentials_path")
+        if path is not None:
+            with open(path, "rb") as f:
+                return base64.b64encode(f.read()).decode("utf-8")
+
+        raise ValueError(
+            "BigQuery service account credentials are required. "
+            "Provide one of: 'credentials_json', 'credentials_base64', "
+            "'credentials_path', or set the BIGQUERY_CREDENTIALS_JSON env var."
+        )
+
+    def _get_engine(self) -> Any:
+        if self._engine is None:
+            from sqlalchemy import create_engine
+
+            project = self._cfg.get("project")
+            if not project:
+                raise ValueError("BigQuery connection config must include 'project'.")
+
+            dataset = self._cfg.get("dataset", "")
+            url = f"bigquery://{project}/{dataset}" if dataset else f"bigquery://{project}"
+
+            credentials_base64 = self._resolve_credentials()
+            self._engine = create_engine(url, credentials_base64=credentials_base64)
+            logger.info(
+                "[BigQuery] engine created for project=%s dataset=%s",
+                project,
+                dataset,
+            )
+        return self._engine
+
+    @staticmethod
+    def _coerce_value(v: Any) -> Any:
+        if isinstance(v, Decimal):
+            return float(v) if v % 1 else int(v)
+        if isinstance(v, (datetime.datetime, datetime.date)):
+            return v.isoformat()
+        if isinstance(v, bytes):
+            return v.hex()
+        if isinstance(v, uuid.UUID):
+            return str(v)
+        return v
+
+    def _run_query(self, sql: str, limit: int | None = None) -> dict:
+        from analytics_agent.config import settings
+
+        try:
+            engine = self._get_engine()
+        except Exception as e:
+            return {"error": str(e), "columns": [], "rows": [], "truncated": False}
+
+        effective_sql = sql.strip().rstrip(";")
+        if limit is not None and "LIMIT" not in effective_sql.upper():
+            effective_sql = f"{effective_sql} LIMIT {limit}"
+
+        try:
+            from sqlalchemy import text
+
+            with engine.connect() as conn:
+                cursor = conn.execute(text(effective_sql))
+                columns = list(cursor.keys()) if cursor.returns_rows else []
+                rows = cursor.fetchall()
+                truncated = len(rows) >= (limit or settings.sql_row_limit)
+                coerced = [
+                    {c: self._coerce_value(v) for c, v in zip(columns, row, strict=False)}
+                    for row in rows
+                ]
+                return {"columns": columns, "rows": coerced, "truncated": truncated}
+        except Exception as e:
+            return {"error": str(e), "columns": [], "rows": [], "truncated": False}
+
+    def get_tools(self) -> list[BaseTool]:
+        engine = self
+
+        @tool
+        def execute_sql(sql: str) -> str:
+            """Execute a SQL query against BigQuery. Returns JSON with columns and rows."""
+            from analytics_agent.config import settings
+
+            result = engine._run_query(sql, limit=settings.sql_row_limit)
+            return orjson.dumps(result).decode()
+
+        @tool
+        def list_tables(schema: str = "") -> str:
+            """List tables in BigQuery. Pass a dataset name to filter, or leave blank for the default dataset."""
+            try:
+                from sqlalchemy import inspect
+
+                inspector = inspect(engine._get_engine())
+                table_names = inspector.get_table_names(schema=schema or None)
+                tables = [{"name": t, "schema": schema or None} for t in table_names]
+                return orjson.dumps(tables).decode()
+            except Exception as e:
+                return orjson.dumps({"error": str(e)}).decode()
+
+        @tool
+        def get_schema(table: str) -> str:
+            """Get the column schema for a BigQuery table. Use dataset.table format if needed."""
+            try:
+                from sqlalchemy import inspect
+
+                # Support dataset.table notation
+                schema, _, tbl = table.partition(".")
+                if not tbl:
+                    tbl, schema = schema, None  # type: ignore[assignment]
+
+                inspector = inspect(engine._get_engine())
+                columns = inspector.get_columns(tbl, schema=schema or None)
+                result = [
+                    {
+                        "name": col["name"],
+                        "type": str(col["type"]),
+                        "nullable": col.get("nullable", True),
+                    }
+                    for col in columns
+                ]
+                return orjson.dumps(result).decode()
+            except Exception as e:
+                return orjson.dumps({"error": str(e)}).decode()
+
+        @tool
+        def preview_table(table: str, limit: int = 10) -> str:
+            """Preview the first N rows of a BigQuery table. Use dataset.table format if needed."""
+            result = engine._run_query(f"SELECT * FROM `{table}`", limit=limit)
+            return orjson.dumps(result).decode()
+
+        return [execute_sql, list_tables, get_schema, preview_table]  # type: ignore[misc]
+
+    async def aclose(self) -> None:
+        if self._engine is not None:
+            self._engine.dispose()
+            self._engine = None

--- a/backend/src/analytics_agent/engines/factory.py
+++ b/backend/src/analytics_agent/engines/factory.py
@@ -9,11 +9,13 @@ _TYPE_MAP_KEY = "snowflake"  # avoid circular import at module level
 
 
 def _engine_cls(engine_type: str):
+    from analytics_agent.engines.bigquery.engine import BigQueryQueryEngine
     from analytics_agent.engines.mcp.engine import MCPQueryEngine
     from analytics_agent.engines.snowflake.engine import SnowflakeQueryEngine
     from analytics_agent.engines.sqlalchemy.engine import SQLAlchemyQueryEngine
 
     return {
+        "bigquery": BigQueryQueryEngine,
         "snowflake": SnowflakeQueryEngine,
         "mysql": SQLAlchemyQueryEngine,
         "sqlite": SQLAlchemyQueryEngine,

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,6 +17,15 @@ context_platforms:
 # don't need. Additional connections can also be added via the Settings UI.
 engines: []
 
+# BigQuery example:
+# engines:
+#  - type: bigquery
+#    name: prod
+#    connection:
+#      project: "${BIGQUERY_PROJECT}"
+#      dataset: "${BIGQUERY_DATASET}" #optional
+#      credentials_path: "${BIGQUERY_CREDENTIALS_PATH}"
+
 # Snowflake example:
 # engines:
 #   - type: snowflake

--- a/frontend/src/components/Settings/connections/index.ts
+++ b/frontend/src/components/Settings/connections/index.ts
@@ -3,6 +3,7 @@ export { AddConnectionFlow } from "./AddConnectionFlow";
 
 import { snowflakePlugin } from "./plugins/snowflake";
 import { snowflakeMcpPlugin } from "./plugins/snowflake-mcp";
+import { bigqueryPlugin } from "./plugins/bigquery";
 import { mysqlPlugin } from "./plugins/mysql";
 import { postgresqlPlugin } from "./plugins/postgresql";
 import { sqlitePlugin } from "./plugins/sqlite";
@@ -17,6 +18,7 @@ export const CONNECTION_PLUGINS: ConnectionPlugin[] = [
   // Engines
   snowflakePlugin,
   snowflakeMcpPlugin,
+  bigqueryPlugin,
   mysqlPlugin,
   postgresqlPlugin,
   sqlitePlugin,

--- a/frontend/src/components/Settings/connections/plugins/bigquery.tsx
+++ b/frontend/src/components/Settings/connections/plugins/bigquery.tsx
@@ -1,0 +1,24 @@
+import { SimpleFormShell } from "../SimpleFormShell";
+import type { ConnectionPlugin, NewConnectionPayload } from "../types";
+
+const FIELDS = [
+  { key: "project",          label: "GCP Project ID",       placeholder: "my-gcp-project", required: true },
+  { key: "dataset",          label: "Default Dataset",       placeholder: "my_dataset" },
+  { key: "credentials_json", label: "Service Account JSON",  type: "password" as const, placeholder: '{"type":"service_account","project_id":"..."}' },
+];
+
+export const bigqueryPlugin: ConnectionPlugin = {
+  id: "bigquery",
+  serviceId: "bigquery",
+  label: "BigQuery",
+  category: "engine",
+  transport: "native",
+  description: "Connect to Google BigQuery",
+  Form: ({ onDone, onCancel }) => (
+    <SimpleFormShell
+      fields={FIELDS}
+      onCancel={onCancel}
+      onDone={(payload: NewConnectionPayload) => onDone(payload)}
+    />
+  ),
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dependencies = [
     # Query engines
     "snowflake-connector-python[pandas,secure-local-storage]>=3.10.0",
     "pymysql>=1.1.0",
+    "sqlalchemy-bigquery>=1.11.0",
+    "google-cloud-bigquery>=3.11.0",
     # Observability (OTEL) — no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set
     "opentelemetry-sdk>=1.25.0",
     "opentelemetry-exporter-otlp-proto-http>=1.25.0",

--- a/tests/unit/test_bigquery_engine.py
+++ b/tests/unit/test_bigquery_engine.py
@@ -1,0 +1,395 @@
+"""
+Tests for the BigQueryQueryEngine introduced in
+analytics_agent/engines/bigquery/engine.py.
+
+Covers:
+- _resolve_credentials() priority order (json → base64 → path) and raises when missing
+- _get_engine() raises ValueError when project is missing
+- _get_engine() raises ValueError when credentials are missing
+- _get_engine() passes credentials_base64 kwarg only when credentials are present
+- _coerce_value() type conversions (Decimal, datetime, date, bytes, UUID, passthrough)
+- _run_query() returns error dict on engine-creation failure
+- _run_query() appends LIMIT clause only when needed
+- _run_query() coerces row values and sets truncated flag correctly
+- get_tools() returns exactly the four expected tool names
+- aclose() disposes the engine and clears internal state
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import json
+import uuid
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DUMMY_B64 = base64.b64encode(b'{"type":"service_account","project_id":"p"}').decode()
+
+
+def _make_engine(cfg: dict | None = None):
+    """Instantiate BigQueryQueryEngine without importing heavy deps at module level."""
+    from analytics_agent.engines.bigquery.engine import BigQueryQueryEngine
+
+    return BigQueryQueryEngine(cfg or {})
+
+
+def _cfg_with_creds(**extra) -> dict:
+    """Return a config dict that always satisfies the credentials requirement."""
+    return {"project": "my-proj", "credentials_base64": _DUMMY_B64, **extra}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCredentials:
+    def test_raises_when_no_credentials(self):
+        """Credentials are now required; ADC fallback has been removed."""
+        eng = _make_engine({"project": "my-proj"})
+        with pytest.raises(ValueError, match="credentials"):
+            eng._resolve_credentials()
+
+    def test_credentials_json_from_config(self):
+        raw = json.dumps({"type": "service_account", "project_id": "p"})
+        eng = _make_engine({"project": "my-proj", "credentials_json": raw})
+        result = eng._resolve_credentials()
+        assert result == base64.b64encode(raw.encode()).decode()
+
+    def test_credentials_json_from_env_var(self, monkeypatch):
+        raw = json.dumps({"type": "service_account", "project_id": "p"})
+        monkeypatch.setenv("BIGQUERY_CREDENTIALS_JSON", raw)
+        eng = _make_engine({"project": "my-proj"})
+        result = eng._resolve_credentials()
+        assert result == base64.b64encode(raw.encode()).decode()
+
+    def test_credentials_json_config_takes_priority_over_env(self, monkeypatch):
+        env_raw = json.dumps({"source": "env"})
+        cfg_raw = json.dumps({"source": "cfg"})
+        monkeypatch.setenv("BIGQUERY_CREDENTIALS_JSON", env_raw)
+        eng = _make_engine({"project": "my-proj", "credentials_json": cfg_raw})
+        result = eng._resolve_credentials()
+        assert result == base64.b64encode(cfg_raw.encode()).decode()
+
+    def test_credentials_base64_from_config(self):
+        b64 = base64.b64encode(b'{"type":"service_account"}').decode()
+        eng = _make_engine({"project": "my-proj", "credentials_base64": b64})
+        assert eng._resolve_credentials() == b64
+
+    def test_credentials_path_reads_file(self, tmp_path):
+        creds_data = b'{"type": "service_account"}'
+        creds_file = tmp_path / "sa.json"
+        creds_file.write_bytes(creds_data)
+        eng = _make_engine({"project": "my-proj", "credentials_path": str(creds_file)})
+        result = eng._resolve_credentials()
+        assert result == base64.b64encode(creds_data).decode()
+
+    def test_priority_json_over_base64(self):
+        raw = json.dumps({"source": "json"})
+        b64_other = base64.b64encode(b'{"source":"b64"}').decode()
+        eng = _make_engine(
+            {
+                "project": "my-proj",
+                "credentials_json": raw,
+                "credentials_base64": b64_other,
+            }
+        )
+        result = eng._resolve_credentials()
+        assert result == base64.b64encode(raw.encode()).decode()
+
+    def test_priority_base64_over_path(self, tmp_path):
+        creds_file = tmp_path / "sa.json"
+        creds_file.write_bytes(b'{"source":"path"}')
+        b64 = base64.b64encode(b'{"source":"b64"}').decode()
+        eng = _make_engine(
+            {
+                "project": "my-proj",
+                "credentials_base64": b64,
+                "credentials_path": str(creds_file),
+            }
+        )
+        assert eng._resolve_credentials() == b64
+
+
+# ---------------------------------------------------------------------------
+# _get_engine
+# ---------------------------------------------------------------------------
+
+
+class TestGetEngine:
+    def test_raises_when_project_missing(self):
+        eng = _make_engine({})
+        with pytest.raises(ValueError, match="project"):
+            eng._get_engine()
+
+    def test_raises_when_credentials_missing(self):
+        """Credentials are required; no ADC fallback."""
+        eng = _make_engine({"project": "my-proj"})
+        with pytest.raises(ValueError, match="credentials"):
+            eng._get_engine()
+
+    def test_creates_engine_with_project_and_credentials(self):
+        eng = _make_engine(_cfg_with_creds())
+        mock_engine = MagicMock()
+        with patch("sqlalchemy.create_engine", return_value=mock_engine) as mock_ce:
+            result = eng._get_engine()
+        url_used = mock_ce.call_args[0][0]
+        assert url_used == "bigquery://my-proj"
+        assert result is mock_engine
+
+    def test_creates_engine_with_dataset(self):
+        eng = _make_engine(_cfg_with_creds(dataset="my_ds"))
+        mock_engine = MagicMock()
+        with patch("sqlalchemy.create_engine", return_value=mock_engine) as mock_ce:
+            eng._get_engine()
+        url_used = mock_ce.call_args[0][0]
+        assert url_used == "bigquery://my-proj/my_ds"
+
+    def test_passes_credentials_base64_when_present(self):
+        raw = json.dumps({"type": "service_account"})
+        eng = _make_engine({"project": "my-proj", "credentials_json": raw})
+        mock_engine = MagicMock()
+        expected_b64 = base64.b64encode(raw.encode()).decode()
+        with patch("sqlalchemy.create_engine", return_value=mock_engine) as mock_ce:
+            eng._get_engine()
+        _, kwargs = mock_ce.call_args
+        assert kwargs.get("credentials_base64") == expected_b64
+
+    def test_engine_is_cached(self):
+        eng = _make_engine(_cfg_with_creds())
+        mock_engine = MagicMock()
+        with patch("sqlalchemy.create_engine", return_value=mock_engine) as mock_ce:
+            first = eng._get_engine()
+            second = eng._get_engine()
+        assert mock_ce.call_count == 1
+        assert first is second
+
+
+# ---------------------------------------------------------------------------
+# _coerce_value
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceValue:
+    @pytest.fixture(autouse=True)
+    def engine(self):
+        from analytics_agent.engines.bigquery.engine import BigQueryQueryEngine
+
+        self.coerce = BigQueryQueryEngine._coerce_value
+
+    def test_decimal_whole_becomes_int(self):
+        assert self.coerce(Decimal("42")) == 42
+        assert isinstance(self.coerce(Decimal("42")), int)
+
+    def test_decimal_fractional_becomes_float(self):
+        assert self.coerce(Decimal("3.14")) == pytest.approx(3.14)
+        assert isinstance(self.coerce(Decimal("3.14")), float)
+
+    def test_datetime_isoformat(self):
+        dt = datetime.datetime(2024, 1, 15, 12, 30, 0)
+        assert self.coerce(dt) == "2024-01-15T12:30:00"
+
+    def test_date_isoformat(self):
+        d = datetime.date(2024, 1, 15)
+        assert self.coerce(d) == "2024-01-15"
+
+    def test_bytes_to_hex(self):
+        assert self.coerce(b"\xde\xad\xbe\xef") == "deadbeef"
+
+    def test_uuid_to_str(self):
+        u = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert self.coerce(u) == "12345678-1234-5678-1234-567812345678"
+
+    def test_passthrough_string(self):
+        assert self.coerce("hello") == "hello"
+
+    def test_passthrough_int(self):
+        assert self.coerce(99) == 99
+
+    def test_passthrough_none(self):
+        assert self.coerce(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _run_query
+# ---------------------------------------------------------------------------
+
+
+class TestRunQuery:
+    def _make_mock_cursor(self, columns, rows, returns_rows=True):
+        cursor = MagicMock()
+        cursor.returns_rows = returns_rows
+        cursor.keys.return_value = columns
+        cursor.fetchall.return_value = rows
+        return cursor
+
+    def test_returns_error_dict_on_engine_failure(self):
+        eng = _make_engine({})  # no project → ValueError on _get_engine
+        result = eng._run_query("SELECT 1")
+        assert "error" in result
+        assert result["columns"] == []
+        assert result["rows"] == []
+        assert result["truncated"] is False
+
+    def test_appends_limit_when_missing(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        cursor = self._make_mock_cursor(["n"], [(1,)])
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value = cursor
+        mock_engine.connect.return_value = mock_conn
+        eng._engine = mock_engine
+
+        with patch("analytics_agent.config.settings") as mock_settings:
+            mock_settings.sql_row_limit = 100
+            with patch("sqlalchemy.text", side_effect=lambda s: s):
+                eng._run_query("SELECT * FROM t", limit=50)
+                executed_sql = mock_conn.execute.call_args[0][0]
+        assert "LIMIT 50" in executed_sql
+
+    def test_does_not_append_limit_when_already_present(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        cursor = self._make_mock_cursor(["n"], [(1,)])
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value = cursor
+        mock_engine.connect.return_value = mock_conn
+        eng._engine = mock_engine
+
+        sql_with_limit = "SELECT * FROM t LIMIT 10"
+        with patch("analytics_agent.config.settings") as mock_settings:
+            mock_settings.sql_row_limit = 100
+            with patch("sqlalchemy.text", side_effect=lambda s: s):
+                eng._run_query(sql_with_limit, limit=50)
+                executed_sql = mock_conn.execute.call_args[0][0]
+        assert executed_sql.count("LIMIT") == 1
+
+    def test_truncated_flag_set_when_rows_equal_limit(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        # Return exactly `limit` rows → truncated should be True
+        cursor = self._make_mock_cursor(["id"], [(i,) for i in range(10)])
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value = cursor
+        mock_engine.connect.return_value = mock_conn
+        eng._engine = mock_engine
+
+        with patch("analytics_agent.config.settings") as mock_settings:
+            mock_settings.sql_row_limit = 10
+            with patch("sqlalchemy.text", side_effect=lambda s: s):
+                result = eng._run_query("SELECT id FROM t", limit=10)
+        assert result["truncated"] is True
+
+    def test_truncated_false_when_fewer_rows_than_limit(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        cursor = self._make_mock_cursor(["id"], [(1,), (2,)])
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value = cursor
+        mock_engine.connect.return_value = mock_conn
+        eng._engine = mock_engine
+
+        with patch("analytics_agent.config.settings") as mock_settings:
+            mock_settings.sql_row_limit = 100
+            with patch("sqlalchemy.text", side_effect=lambda s: s):
+                result = eng._run_query("SELECT id FROM t", limit=100)
+        assert result["truncated"] is False
+
+    def test_row_values_are_coerced(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        dt = datetime.date(2024, 6, 1)
+        cursor = self._make_mock_cursor(["d"], [(dt,)])
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value = cursor
+        mock_engine.connect.return_value = mock_conn
+        eng._engine = mock_engine
+
+        with patch("analytics_agent.config.settings") as mock_settings:
+            mock_settings.sql_row_limit = 100
+            with patch("sqlalchemy.text", side_effect=lambda s: s):
+                result = eng._run_query("SELECT d FROM t")
+        assert result["rows"][0]["d"] == "2024-06-01"
+
+    def test_returns_error_dict_on_query_failure(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.side_effect = Exception("syntax error")
+        mock_engine.connect.return_value = mock_conn
+        eng._engine = mock_engine
+
+        with patch("analytics_agent.config.settings") as mock_settings:
+            mock_settings.sql_row_limit = 100
+            with patch("sqlalchemy.text", side_effect=lambda s: s):
+                result = eng._run_query("BAD SQL")
+        assert "error" in result
+        assert "syntax error" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_tools
+# ---------------------------------------------------------------------------
+
+
+class TestGetTools:
+    def test_returns_four_tools(self):
+        eng = _make_engine(_cfg_with_creds())
+        tools = eng.get_tools()
+        assert len(tools) == 4
+
+    def test_tool_names(self):
+        eng = _make_engine(_cfg_with_creds())
+        names = {t.name for t in eng.get_tools()}
+        assert names == {"execute_sql", "list_tables", "get_schema", "preview_table"}
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+class TestAclose:
+    @pytest.mark.asyncio
+    async def test_disposes_engine_and_clears_state(self):
+        eng = _make_engine({"project": "p"})
+        mock_engine = MagicMock()
+        eng._engine = mock_engine
+        await eng.aclose()
+        mock_engine.dispose.assert_called_once()
+        assert eng._engine is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_noop_when_no_engine(self):
+        eng = _make_engine({"project": "p"})
+        # Should not raise
+        await eng.aclose()
+
+
+# ---------------------------------------------------------------------------
+# datahub_platform property
+# ---------------------------------------------------------------------------
+
+
+def test_datahub_platform_name():
+    eng = _make_engine({"project": "p"})
+    assert eng.datahub_platform == "bigquery"

--- a/uv.lock
+++ b/uv.lock
@@ -723,6 +723,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "datahub-agent-context", extra = ["langchain"] },
     { name = "fastapi" },
+    { name = "google-cloud-bigquery" },
     { name = "httpx" },
     { name = "jsonschema" },
     { name = "keyring" },
@@ -743,6 +744,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "snowflake-connector-python", extra = ["pandas", "secure-local-storage"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sqlalchemy-bigquery" },
     { name = "tiktoken" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -777,6 +779,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "datahub-agent-context", extras = ["langchain"], specifier = ">=1.5.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-cloud-bigquery", specifier = ">=3.11.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -802,6 +805,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "snowflake-connector-python", extras = ["pandas", "secure-local-storage"], specifier = ">=3.10.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
+    { name = "sqlalchemy-bigquery", specifier = ">=1.11.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "types-pymysql", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
@@ -1011,6 +1015,28 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1026,6 +1052,67 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-resumable-media" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/13/6515c7aab55a4a0cf708ffd309fb9af5bab54c13e32dc22c5acd6497193c/google_cloud_bigquery-3.41.0.tar.gz", hash = "sha256:2217e488b47ed576360c9b2cc07d59d883a54b83167c0ef37f915c26b01a06fe", size = 513434, upload-time = "2026-03-30T22:50:55.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/33/1d3902efadef9194566d499d61507e1f038454e0b55499d2d7f8ab2a4fee/google_cloud_bigquery-3.41.0-py3-none-any.whl", hash = "sha256:2a5b5a737b401cbd824a6e5eac7554100b878668d908e6548836b5d8aaa4dcaa", size = 262343, upload-time = "2026-03-30T22:48:45.444Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/24/6ca08b0a03c7b0c620427503ab00353a4ae806b848b93bcea18b6b76fde6/google_cloud_core-2.5.1.tar.gz", hash = "sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811", size = 36078, upload-time = "2026-03-30T22:50:08.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d9/5bb050cb32826466aa9b25f79e2ca2879fe66cb76782d4ed798dd7506151/google_cloud_core-2.5.1-py3-none-any.whl", hash = "sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7", size = 29452, upload-time = "2026-03-30T22:48:31.567Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
 ]
 
 [[package]]
@@ -1099,6 +1186,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/14/ea/144bbc4b9359da89aec07b4c2a91a6bfe7119914885386577c665b07bb01/google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8", size = 433773, upload-time = "2025-11-05T14:58:01.594Z" },
     { url = "https://files.pythonhosted.org/packages/96/b3/74e301211699f1b650ba7690a3e4e52146ac4266fcd62f3ea0a945b9eda4/google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6", size = 491893, upload-time = "2025-11-05T14:58:02.969Z" },
     { url = "https://files.pythonhosted.org/packages/6f/d1/4adcfcb9c95e3d064c9f7aaf6cb3a4fc842d86115014b9d4094db4d465b5/google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5", size = 643093, upload-time = "2025-11-05T14:58:05.761Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/d1/b1ea14b93b6b78f57fc580125de44e9f593ab88dd2460f1a8a8d18f74754/google_resumable_media-2.8.2.tar.gz", hash = "sha256:f3354a182ebd193ae3f42e3ef95e6c9b10f128320de23ac7637236713b1acd70", size = 2164510, upload-time = "2026-03-30T23:34:25.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f8/50bfaf4658431ff9de45c5c3935af7ab01157a4903c603cd0eee6e78e087/google_resumable_media-2.8.2-py3-none-any.whl", hash = "sha256:82b6d8ccd11765268cdd2a2123f417ec806b8eef3000a9a38dfe3033da5fb220", size = 81511, upload-time = "2026-03-30T23:34:09.671Z" },
 ]
 
 [[package]]
@@ -1177,6 +1276,71 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
 ]
 
 [[package]]
@@ -2771,6 +2935,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3782,6 +3958,22 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "greenlet" },
+]
+
+[[package]]
+name = "sqlalchemy-bigquery"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-bigquery" },
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/6a/c49932b3d9c44cab9202b1866c5b36b7f0d0455d4653fbc0af4466aeaa76/sqlalchemy_bigquery-1.16.0.tar.gz", hash = "sha256:fe937a0d1f4cf7219fcf5d4995c6718805b38d4df43e29398dec5dc7b6d1987e", size = 119632, upload-time = "2025-11-06T01:35:40.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/87/11e6de00ef7949bb8ea06b55304a1a4911c329fdf0d9882b464db240c2c5/sqlalchemy_bigquery-1.16.0-py3-none-any.whl", hash = "sha256:0fe7634cd954f3e74f5e2db6d159f9e5ee87a47fbe8d52eac3cd3bb3dadb3a77", size = 40615, upload-time = "2025-11-06T01:35:39.358Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds full BigQuery support as a pluggable query engine, alongside the existing connectors.

Backend
New BigQueryQueryEngine in engines/bigquery/engine.py with four LangChain tools: execute_sql, list_tables, get_schema, preview_table
Credentials resolved in priority order: credentials_json (config or BIGQUERY_CREDENTIALS_JSON env var) → credentials_base64 → credentials_path; raises explicitly if no credentials are found (ADC fallback removed from initial draft)
Registered in factory.py as engine type "bigquery"
settings.py updated to expose BigQuery connection status and fields for both config.yaml-based and database-stored connections

Frontend
New bigquery.tsx plugin with form fields for GCP Project ID, Default Dataset, and Service Account JSON
Registered in index.ts under CONNECTION_PLUGINS

Docs
README.md updated with a dedicated BigQuery section covering authentication options (env var, base64, path to file), minimum required IAM roles (bigquery.dataViewer + bigquery.jobUser), and config.yaml examples

Tests
Unit test suite in test_bigquery_engine.py covering credential resolution priority, engine creation, type coercion, query behavior, and aclose() lifecycle

Dependencies
Added sqlalchemy-bigquery>=1.11.0 and google-cloud-bigquery>=3.11.0 to pyproject.toml

.env
BigQuery  (if using bigquery engine)..

config.yaml
engines:..