### PR TITLE
fix: BigQuery shows connected when project set but no credentials

### DIFF
--- a/backend/src/analytics_agent/api/settings.py
+++ b/backend/src/analytics_agent/api/settings.py
@@ -426,8 +426,7 @@ def _get_engine_connections(disabled: set[str]) -> list[ConnectionStatus]:
             creds_path = connection.get("credentials_path", "")
             creds_b64 = connection.get("credentials_base64", "")
             has_creds = bool(creds_json or creds_path or creds_b64)
-            # ADC is always available as fallback; configured = project is set
-            configured = bool(project)
+            configured = bool(project and has_creds)
             conns.append(
                 ConnectionStatus(
                     name=name,
@@ -652,7 +651,7 @@ async def list_connections(session: AsyncSession = Depends(get_session)):
             creds_path = conn_cfg.get("credentials_path", "")
             creds_b64 = conn_cfg.get("credentials_base64", "")
             has_creds = bool(creds_json or creds_path or creds_b64)
-            status_str = "connected" if project else "unconfigured"
+            status_str = "connected" if (project and has_creds) else "unconfigured"
             fields = [
                 ConnectionField(
                     key="project",


### PR DESCRIPTION
## Summary

- Both the config.yaml path and the DB-stored path in `_get_engine_connections` computed `has_creds` but based the status on `bool(project)` alone
- A BigQuery connection with `project` set but no credentials showed green/Connected in the Settings UI, then raised `ValueError` at query time
- Removes the stale `# ADC is always available as fallback` comment

## Changes

`api/settings.py` — two one-line fixes:

```python
# before
configured = bool(project)

# after  
configured = bool(project and has_creds)
```

Same fix applied to both the config.yaml path and the DB-stored connection path.

## Test plan

- [x] All 191 unit tests pass
- [x] Syntax check clean

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)