### PR TITLE
feat: render charts outside the collapsible work block

### DIFF
--- a/frontend/src/components/Chat/MessageList.tsx
+++ b/frontend/src/components/Chat/MessageList.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useRef } from "react";
 import type { UIMessage } from "@/types";
 import { TextMessage } from "./messages/TextMessage";
 import { AgentWorkBlock } from "./messages/AgentWorkBlock";
+import { ChartMessage } from "./messages/ChartMessage";
 import { groupIntoTurns } from "@/lib/groupMessages";
 
 interface Props {
@@ -43,7 +44,7 @@ export function MessageList({ messages, isStreaming = false, showReasoning = tru
             </div>
           )}
 
-          {/* Agent work block — only shown when there are intermediate steps */}
+          {/* Agent work block — tool calls, SQL, thinking. Charts are excluded. */}
           {group.workMsgs.length > 0 && (
             <AgentWorkBlock
               workMessages={group.workMsgs}
@@ -53,6 +54,16 @@ export function MessageList({ messages, isStreaming = false, showReasoning = tru
               onChartError={onChartError}
             />
           )}
+
+          {/* Charts rendered OUTSIDE the work block so they stay visible when it collapses. */}
+          {group.chartMsgs.map((msg) => (
+            <div key={msg.id} className="w-full" data-print-role="chart">
+              <ChartMessage
+                payload={msg.payload as never}
+                onRenderError={onChartError}
+              />
+            </div>
+          ))}
 
           {/* Final visible response */}
           {group.finalMsg && (group.finalMsg.payload as { text?: string }).text?.trim() && (

--- a/frontend/src/lib/groupMessages.ts
+++ b/frontend/src/lib/groupMessages.ts
@@ -1,37 +1,42 @@
 import type { UIMessage, TurnUsage } from "@/types";
 
-const WORK_TYPES = new Set(["TOOL_CALL", "TOOL_RESULT", "SQL", "CHART", "ERROR", "THINKING"]);
+const WORK_TYPES = new Set(["TOOL_CALL", "TOOL_RESULT", "SQL", "ERROR", "THINKING"]);
 
 export interface TurnGroup {
   key: string;
   userMsg?: UIMessage;
   workMsgs: UIMessage[];
+  /** Chart events extracted from workMsgs — rendered outside the collapsible work block. */
+  chartMsgs: UIMessage[];
   finalMsg?: UIMessage;
   isActivelyStreaming: boolean;
 }
 
 export function groupIntoTurns(messages: UIMessage[], globalStreaming: boolean): TurnGroup[] {
   const groups: TurnGroup[] = [];
-  let current: TurnGroup = { key: "init", workMsgs: [], isActivelyStreaming: false };
+  let current: TurnGroup = { key: "init", workMsgs: [], chartMsgs: [], isActivelyStreaming: false };
 
   for (const msg of messages) {
     if (msg.role === "user") {
-      if (current.userMsg || current.workMsgs.length > 0 || current.finalMsg) {
+      if (current.userMsg || current.workMsgs.length > 0 || current.chartMsgs.length > 0 || current.finalMsg) {
         groups.push(current);
       }
-      current = { key: msg.id, userMsg: msg, workMsgs: [], isActivelyStreaming: false };
+      current = { key: msg.id, userMsg: msg, workMsgs: [], chartMsgs: [], isActivelyStreaming: false };
       continue;
     }
 
     if (msg.event_type === "TEXT" && !msg.isThinking) {
       if (msg.isStreaming) current.isActivelyStreaming = true;
       current.finalMsg = msg;
+    } else if (msg.event_type === "CHART") {
+      // Charts rendered outside the collapsible work block so they stay visible when collapsed.
+      current.chartMsgs.push(msg);
     } else if (WORK_TYPES.has(msg.event_type) || (msg.event_type === "TEXT" && msg.isThinking)) {
       current.workMsgs.push(msg);
     }
   }
 
-  if (current.userMsg || current.workMsgs.length > 0 || current.finalMsg) {
+  if (current.userMsg || current.workMsgs.length > 0 || current.chartMsgs.length > 0 || current.finalMsg) {
     if (globalStreaming && !current.finalMsg?.isStreaming) {
       current.isActivelyStreaming = globalStreaming;
     }


### PR DESCRIPTION
## Summary

Charts (CHART events) were rendered inside `AgentWorkBlock`, which collapses 600ms after streaming ends — hiding the visualisation from the user.

- `groupMessages.ts`: CHART removed from `WORK_TYPES`; `TurnGroup` gains a `chartMsgs` field that separates chart events from the collapsible work steps
- `MessageList.tsx`: `chartMsgs` rendered between the work block and the final text response — always visible regardless of collapse state

**Rendering order per turn (after this change):**
1. User message
2. AgentWorkBlock (tool calls + SQL — collapses after streaming) ← charts no longer here
3. Chart(s) ← always visible
4. Final text response

The SQL tables that generated the chart remain inside the work block as context, expandable on demand.

## Test plan

- [ ] Ask a question that generates a chart (e.g. "show monthly order volumes as a chart")
- [ ] Verify chart is visible after the work block collapses
- [ ] Verify chart appears between the work block and the final text
- [ ] Verify multiple charts in one turn stack correctly
- [ ] Verify no regression for turns without charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)