### PR TITLE
fix: bundle frontend in published wheel and register CLI alias for uvx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd frontend && pnpm install --frozen-lockfile && pnpm build
 
       - name: Build package
-        run: uv build
+        run: uv build --wheel
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ Repository = "https://github.com/datahub-project/analytics-agent"
 
 [project.scripts]
 analytics-agent = "analytics_agent.cli:cli"
+datahub-analytics-agent = "analytics_agent.cli:cli"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Two 1-line fixes for the pip/uvx install path. Verified locally.

## Bug 1: Wheel published without frontend

`pip install datahub-analytics-agent` followed by `analytics-agent quickstart` reports `✓ Running at http://localhost:8100`, but the browser returns `{"detail":"Not Found"}`.

<img width="602" height="149" alt="image" src="https://github.com/user-attachments/assets/ce0953bb-d2be-40a5-9cb0-24571ed48418" />

**Cause:** `publish.yml` ran `uv build`, which builds via sdist intermediary. The sdist excludes `frontend/dist/` (gitignored), so the wheel was produced without the UI.

**Fix:** `uv build` → `uv build --wheel` in `.github/workflows/publish.yml`. Hatchling now builds directly from the source tree where `frontend/dist/` exists.

## Bug 2: `uvx datahub-analytics-agent quickstart` fails

``` 
An executable named `datahub-analytics-agent` is not provided by package `datahub-analytics-agent`.
```
**Cause:** Package is `datahub-analytics-agent`, executable was registered only as `analytics-agent`. uvx assumes they match.

**Fix:** Registered `datahub-analytics-agent` as an alias in `pyproject.toml`. Both invocations now work; existing scripts using `analytics-agent` are unaffected.

## Notes

- `bash quickstart.sh` is unaffected — uses Docker, bakes frontend inside the image.
- README requires no changes; all documented commands work after these fixes.