### PR TITLE
chore: bump version to 0.2.2 and validate tag/version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Build frontend
         run: cd frontend && pnpm install --frozen-lockfile && pnpm build
 
+      - name: Validate tag matches package version
+        run: |
+          PKG_VERSION=$(uv run python -c "import importlib.metadata; print(importlib.metadata.version('datahub-analytics-agent'))")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: pyproject.toml version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "✓ Version $PKG_VERSION matches tag $GITHUB_REF_NAME"
+
       - name: Build package
         run: uv build --wheel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datahub-analytics-agent"
-version = "0.2.1"
+version = "0.2.2"
 description = "Open-source talk-to-data agent with DataHub context and pluggable query engines"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ langchain = [
 
 [[package]]
 name = "datahub-analytics-agent"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "acryl-datahub" },


### PR DESCRIPTION
## Summary

- Bumps package version to `0.2.2`
- Adds a validation step in the publish workflow that fails fast if the `pyproject.toml` version doesn't match the pushed tag — prevents re-uploading an existing version to PyPI

## Context

The `v0.2.2` tag was created on a commit where `pyproject.toml` still had `0.2.1`, causing the publish workflow to try uploading `datahub_analytics_agent-0.2.1` again. PyPI rejected it with `400 File already exists`.

## After merging

Delete and recreate the `v0.2.2` tag on the merge commit so the publish workflow runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)