### PR TITLE
feat: OpenAI-compatible proxy support (LiteLLM, vLLM, Ollama)

### DIFF
--- a/.github/workflows/integration-ollama.yml
+++ b/.github/workflows/integration-ollama.yml
@@ -1,0 +1,64 @@
+name: Integration — OpenAI-compatible proxy (Ollama)
+
+# Only runs when files in the LLM provider flow change, keeping it out of the
+# critical path for unrelated PRs.  The same tests run against a mock server
+# in the standard unit-test job on every push; this job proves the full stack
+# against a real model.
+on:
+  push:
+    branches: [main]
+    paths:
+      - backend/src/analytics_agent/agent/llm.py
+      - backend/src/analytics_agent/config.py
+      - backend/src/analytics_agent/api/settings.py
+      - backend/src/analytics_agent/main.py
+      - tests/unit/test_openai_compat_proxy.py
+  pull_request:
+    branches: [main]
+    paths:
+      - backend/src/analytics_agent/agent/llm.py
+      - backend/src/analytics_agent/config.py
+      - backend/src/analytics_agent/api/settings.py
+      - backend/src/analytics_agent/main.py
+      - tests/unit/test_openai_compat_proxy.py
+
+jobs:
+  ollama-proxy:
+    name: OpenAI-compatible proxy via Ollama
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Install Ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      # Cache the model weights so subsequent runs skip the 1.3 GB download.
+      - name: Cache Ollama model
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama/models
+          key: ollama-llama3.2-1b-v1
+
+      - name: Start Ollama server
+        run: ollama serve &
+
+      - name: Pull llama3.2:1b
+        run: |
+          # Wait for the server to be ready, then pull (no-op if cached).
+          until curl -sf http://localhost:11434/api/tags > /dev/null; do sleep 1; done
+          ollama pull llama3.2:1b
+
+      - name: Run integration tests against Ollama
+        env:
+          OPENAI_COMPAT_TEST_URL: http://localhost:11434/v1
+          OPENAI_COMPAT_TEST_MODEL: llama3.2:1b
+        run: uv run pytest tests/unit/test_openai_compat_proxy.py -v

--- a/backend/src/analytics_agent/agent/llm.py
+++ b/backend/src/analytics_agent/agent/llm.py
@@ -50,12 +50,30 @@ def _make_bedrock(model: str, streaming: bool) -> BaseChatModel:
     return ChatBedrockConverse(**kwargs)
 
 
+def _make_openai_compat(model: str, streaming: bool) -> BaseChatModel:
+    from langchain_openai import ChatOpenAI
+
+    if not settings.openai_compat_base_url:
+        raise ValueError("OPENAI_COMPAT_BASE_URL is required for the openai-compatible provider")
+    kwargs: dict = {
+        "model": model,
+        "temperature": 0,
+        "streaming": streaming,
+        "base_url": settings.openai_compat_base_url,
+    }
+    # API key is optional — some proxies use network-level auth or no auth.
+    api_key = settings.openai_compat_api_key or "no-key"
+    kwargs["api_key"] = SecretStr(api_key)
+    return ChatOpenAI(**kwargs)
+
+
 # Registry — adding a provider means adding one entry here.
 _FACTORIES: dict[str, Callable[[str, bool], BaseChatModel]] = {
     "anthropic": _make_anthropic,
     "openai": _make_openai,
     "google": _make_google,
     "bedrock": _make_bedrock,
+    "openai-compatible": _make_openai_compat,
 }
 
 

--- a/backend/src/analytics_agent/api/settings.py
+++ b/backend/src/analytics_agent/api/settings.py
@@ -1826,6 +1826,8 @@ class LlmSettingsResponse(BaseModel):
     has_aws_keys: bool = False
     aws_region: str = ""
     enable_prompt_cache: bool = True
+    # OpenAI-compatible proxy (LiteLLM, vLLM, Ollama, etc.)
+    base_url: str = ""
 
 
 class UpdateLlmSettingsRequest(BaseModel):
@@ -1839,6 +1841,8 @@ class UpdateLlmSettingsRequest(BaseModel):
     aws_session_token: str = ""
     # Prompt caching for system prompt + tool definitions (Anthropic + Bedrock).
     enable_prompt_cache: bool = True
+    # OpenAI-compatible proxy base URL (plaintext — not a secret).
+    base_url: str = ""
 
 
 @router.get("/llm", response_model=LlmSettingsResponse)
@@ -1868,6 +1872,7 @@ async def get_llm_settings() -> LlmSettingsResponse:
         has_aws_keys=has_aws_keys,
         aws_region=cfg.aws_region,
         enable_prompt_cache=cfg.enable_prompt_cache,
+        base_url=cfg.openai_compat_base_url if provider == "openai-compatible" else "",
     )
 
 
@@ -1880,6 +1885,8 @@ class TestLlmKeyRequest(BaseModel):
     aws_access_key_id: str = ""
     aws_secret_access_key: str = ""
     aws_session_token: str = ""
+    # OpenAI-compatible proxy base URL.
+    base_url: str = ""
 
 
 class TestLlmKeyResponse(BaseModel):
@@ -1938,6 +1945,18 @@ async def test_llm_key(body: TestLlmKeyRequest) -> TestLlmKeyResponse:
                 if tok:
                     bk_kwargs["aws_session_token"] = SecretStr(tok)
             llm = ChatBedrockConverse(**bk_kwargs)
+        elif body.provider == "openai-compatible":
+            from langchain_openai import ChatOpenAI
+
+            if not body.base_url:
+                raise ValueError("Proxy base URL is required for openai-compatible provider")
+            llm = ChatOpenAI(  # type: ignore[assignment]
+                model=model or "default",
+                max_tokens=1,
+                temperature=0,
+                base_url=body.base_url,
+                api_key=SecretStr(body.api_key or "no-key"),  # type: ignore[call-arg]
+            )
         else:
             from langchain_openai import ChatOpenAI
 
@@ -2011,6 +2030,9 @@ async def update_llm_settings(
         new_cfg["aws_session_token"] = _fernet_encrypt(body.aws_session_token)
     # Bool — always persisted (no truthy gate; the user may want to set it false).
     new_cfg["enable_prompt_cache"] = "true" if body.enable_prompt_cache else "false"
+    # OpenAI-compatible proxy base URL — plaintext, not a secret.
+    if body.base_url:
+        new_cfg["base_url"] = body.base_url
 
     await repo.set(_KEY_LLM_CONFIG, orjson.dumps(new_cfg).decode())
 
@@ -2045,6 +2067,9 @@ async def update_llm_settings(
         cfg.aws_session_token = body.aws_session_token
     cfg.enable_prompt_cache = body.enable_prompt_cache
     os.environ["ENABLE_PROMPT_CACHE"] = "true" if body.enable_prompt_cache else "false"
+    if body.base_url:
+        os.environ["OPENAI_COMPAT_BASE_URL"] = body.base_url
+        cfg.openai_compat_base_url = body.base_url
 
     return {"success": True, "message": "LLM settings saved."}
 

--- a/backend/src/analytics_agent/config.py
+++ b/backend/src/analytics_agent/config.py
@@ -178,7 +178,7 @@ class Settings(BaseSettings):
     google_api_key: str = ""
     # OpenAI-compatible proxy (LiteLLM, vLLM, Ollama, etc.)
     openai_compat_base_url: str = ""  # OPENAI_COMPAT_BASE_URL
-    openai_compat_api_key: str = ""   # OPENAI_COMPAT_API_KEY
+    openai_compat_api_key: str = ""  # OPENAI_COMPAT_API_KEY
 
     # Bedrock — uses the standard AWS credential chain by default (env vars,
     # ~/.aws/credentials, IAM role). Set the explicit *_key_id/*_access_key

--- a/backend/src/analytics_agent/config.py
+++ b/backend/src/analytics_agent/config.py
@@ -137,6 +137,14 @@ PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
         "quality": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "delight": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
     },
+    # OpenAI-compatible proxy (LiteLLM, vLLM, Ollama, etc.).
+    # No curated model list — available models depend on the proxy configuration.
+    "openai-compatible": {
+        "main": "",
+        "chart": "",
+        "quality": "",
+        "delight": "",
+    },
 }
 
 # Env var name that holds the API key for each provider.
@@ -144,6 +152,7 @@ PROVIDER_KEY_ENV: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
     "google": "GOOGLE_API_KEY",
+    "openai-compatible": "OPENAI_COMPAT_API_KEY",
 }
 
 # Settings attribute name for each provider's API key.
@@ -151,6 +160,7 @@ PROVIDER_KEY_ATTR: dict[str, str] = {
     "anthropic": "anthropic_api_key",
     "openai": "openai_api_key",
     "google": "google_api_key",
+    "openai-compatible": "openai_compat_api_key",
 }
 
 
@@ -166,6 +176,10 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     google_api_key: str = ""
+    # OpenAI-compatible proxy (LiteLLM, vLLM, Ollama, etc.)
+    openai_compat_base_url: str = ""  # OPENAI_COMPAT_BASE_URL
+    openai_compat_api_key: str = ""   # OPENAI_COMPAT_API_KEY
+
     # Bedrock — uses the standard AWS credential chain by default (env vars,
     # ~/.aws/credentials, IAM role). Set the explicit *_key_id/*_access_key
     # settings to override.

--- a/backend/src/analytics_agent/main.py
+++ b/backend/src/analytics_agent/main.py
@@ -320,6 +320,12 @@ async def _load_llm_config_from_db() -> None:
             os.environ[env_var] = value
             setattr(settings, attr, value)
 
+    # OpenAI-compatible proxy base URL (plaintext).
+    base_url = cfg_data.get("base_url", "")
+    if base_url and not os.environ.get("OPENAI_COMPAT_BASE_URL"):
+        settings.openai_compat_base_url = base_url
+        os.environ["OPENAI_COMPAT_BASE_URL"] = base_url
+
     # Prompt caching toggle (bool stored as "true"/"false" string).
     if "enable_prompt_cache" in cfg_data and not os.environ.get("ENABLE_PROMPT_CACHE"):
         raw_flag = cfg_data["enable_prompt_cache"]

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -247,6 +247,7 @@ export interface LlmSettings {
   has_aws_keys?: boolean;
   aws_region?: string;
   enable_prompt_cache?: boolean;
+  base_url?: string;
 }
 
 /** Bedrock-only credential fields. All optional — leave blank to use the
@@ -268,6 +269,7 @@ export async function testLlmKey(s: {
   provider: string;
   api_key: string;
   model?: string;
+  base_url?: string;
 } & BedrockCredentials): Promise<{ ok: boolean; message: string }> {
   const res = await fetch("/api/settings/llm/test", {
     method: "POST",
@@ -276,6 +278,7 @@ export async function testLlmKey(s: {
       provider: s.provider,
       api_key: s.api_key,
       model: s.model ?? "",
+      base_url: s.base_url ?? "",
       aws_region: s.aws_region ?? "",
       aws_access_key_id: s.aws_access_key_id ?? "",
       aws_secret_access_key: s.aws_secret_access_key ?? "",
@@ -291,6 +294,7 @@ export async function saveLlmSettings(s: {
   api_key: string;
   model?: string;
   enable_prompt_cache?: boolean;
+  base_url?: string;
 } & BedrockCredentials): Promise<void> {
   const res = await fetch("/api/settings/llm", {
     method: "PUT",
@@ -299,6 +303,7 @@ export async function saveLlmSettings(s: {
       provider: s.provider,
       api_key: s.api_key,
       model: s.model ?? "",
+      base_url: s.base_url ?? "",
       aws_region: s.aws_region ?? "",
       aws_access_key_id: s.aws_access_key_id ?? "",
       aws_secret_access_key: s.aws_secret_access_key ?? "",

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -3,7 +3,7 @@ import { Check, Eye, EyeOff, Loader2, X } from "lucide-react";
 import { saveDisplaySettings, saveLlmSettings, testLlmKey } from "@/api/settings";
 import { useDisplayStore } from "@/store/display";
 
-type Provider = "anthropic" | "openai" | "google" | "bedrock";
+type Provider = "anthropic" | "openai" | "google" | "bedrock" | "openai-compatible";
 
 interface WizardProps {
   onComplete: () => void;
@@ -35,16 +35,20 @@ const MODELS: Record<Provider, { value: string; label: string; note: string }[]>
     { value: "us.anthropic.claude-haiku-4-5-20251001-v1:0",  label: "Claude Haiku 4.5 (Bedrock)",  note: "Fastest"     },
     { value: CUSTOM_MODEL_VALUE,                              label: "Custom model ID",            note: "Enter your own" },
   ],
+  "openai-compatible": [
+    { value: CUSTOM_MODEL_VALUE, label: "Model name", note: "Set by your proxy" },
+  ],
 };
 
 function defaultModelFor(p: Provider): string {
-  return p === "bedrock" ? MODELS[p][0].value : MODELS[p][1].value;
+  return p === "bedrock" || p === "openai-compatible" ? MODELS[p][0].value : MODELS[p][1].value;
 }
 
 const providerLabel = (p: Provider) =>
   p === "anthropic" ? "Anthropic"
     : p === "openai" ? "OpenAI"
     : p === "google" ? "Google"
+    : p === "openai-compatible" ? "OpenAI-compatible"
     : "AWS Bedrock";
 
 // ─── Step 1 — warm inline sentence ────────────────────────────────────────────
@@ -154,6 +158,7 @@ interface Step2Props {
   model: string;        onModel: (m: string) => void;
   customModel: string;  onCustomModel: (m: string) => void;
   apiKey: string;       onApiKey: (k: string) => void;
+  baseUrl: string;      onBaseUrl: (v: string) => void;
   awsRegion: string;    onAwsRegion: (v: string) => void;
   awsAccessKey: string; onAwsAccessKey: (v: string) => void;
   awsSecret: string;    onAwsSecret: (v: string) => void;
@@ -180,7 +185,7 @@ function Step2Model(p: Step2Props) {
       </div>
 
       <div className="flex flex-wrap rounded-xl border border-border p-1 gap-1 mb-7 w-fit">
-        {(["anthropic", "openai", "google", "bedrock"] as Provider[]).map((name) => (
+        {(["anthropic", "openai", "google", "bedrock", "openai-compatible"] as Provider[]).map((name) => (
           <button
             key={name}
             type="button"
@@ -243,8 +248,47 @@ function Step2Model(p: Step2Props) {
       )}
       {!isCustom && <div className="mb-6" />}
 
-      {/* Credentials — either a single API key field OR AWS fields for Bedrock. */}
-      {p.provider === "bedrock" ? (
+      {/* Credentials — proxy URL + optional key, single API key, or Bedrock AWS fields. */}
+      {p.provider === "openai-compatible" ? (
+        <div className="space-y-3">
+          <div>
+            <label className="text-sm font-medium text-foreground">Proxy base URL</label>
+            <input
+              type="url"
+              value={p.baseUrl}
+              onChange={(e) => p.onBaseUrl(e.target.value)}
+              onBlur={() => { if (p.baseUrl.trim()) p.onVerify(); }}
+              placeholder="https://litellm.myorg.com"
+              className="w-full mt-1 bg-background border border-border rounded-xl px-4 py-3
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50 placeholder:text-muted-foreground/30"
+            />
+            <p className="text-xs text-muted-foreground/50 mt-1">
+              Any OpenAI-compatible endpoint — LiteLLM, vLLM, Ollama, etc.
+            </p>
+          </div>
+          <div className="relative">
+            <input
+              type="password"
+              value={p.apiKey}
+              onChange={(e) => p.onApiKey(e.target.value)}
+              placeholder="API key (optional)"
+              className="w-full bg-background border border-border rounded-xl px-4 py-2.5
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50 placeholder:text-muted-foreground/30"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={p.onVerify}
+            disabled={p.keyStatus.state === "testing" || !p.baseUrl.trim()}
+            className="text-sm px-4 py-2 rounded-lg border border-border
+                       hover:bg-muted/50 transition-colors disabled:opacity-40"
+          >
+            {p.keyStatus.state === "testing" ? "Verifying…" : "Verify connection"}
+          </button>
+        </div>
+      ) : p.provider === "bedrock" ? (
         <div className="space-y-3">
           <div>
             <label className="text-sm font-medium text-foreground">AWS credentials</label>
@@ -355,7 +399,7 @@ function Step2Model(p: Step2Props) {
             <X className="w-3 h-3" strokeWidth={3} /> {p.keyStatus.msg}
           </p>
         )}
-        {p.keyStatus.state === "idle" && p.provider !== "bedrock" && (
+        {p.keyStatus.state === "idle" && p.provider !== "bedrock" && p.provider !== "openai-compatible" && (
           <p className="text-xs text-muted-foreground/50">
             {p.provider === "anthropic"
               ? "console.anthropic.com/settings/api-keys"
@@ -410,6 +454,7 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
   const [model, setModel] = useState(defaultModelFor("anthropic"));
   const [customModel, setCustomModel] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
   const [awsRegion, setAwsRegion] = useState("us-west-2");
   const [awsAccessKey, setAwsAccessKey] = useState("");
   const [awsSecret, setAwsSecret] = useState("");
@@ -417,7 +462,7 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
   const [keyStatus, setKeyStatus] = useState<KeyStatus>({ state: "idle" });
 
   // Reset verification whenever any credential field changes.
-  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, provider, awsAccessKey, awsSecret, awsRegion, awsSessionToken, customModel]);
+  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, baseUrl, provider, awsAccessKey, awsSecret, awsRegion, awsSessionToken, customModel]);
 
   const [step, setStep] = useState(0);
   const [animKey, setAnimKey] = useState(0);
@@ -429,11 +474,13 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
   const effectiveModel = isCustomModel ? customModel.trim() : model;
 
   // Step 2 advance rules:
-  //  - Bedrock: allow as long as we have a model and verification didn't fail
-  //    (empty AWS fields are valid — means "use default credential chain").
+  //  - Bedrock: allow as long as we have a model and verification didn't fail.
+  //  - openai-compatible: require a base URL (API key is optional).
   //  - Others: require an API key that isn't known-bad.
   const canAdvanceStep2 = provider === "bedrock"
     ? !!effectiveModel && keyStatus.state !== "fail"
+    : provider === "openai-compatible"
+    ? baseUrl.trim().length > 0 && !!effectiveModel && keyStatus.state !== "fail"
     : apiKey.trim().length > 0 && keyStatus.state !== "fail";
   const canContinue = step === 0 ? agentName.trim().length > 0 : canAdvanceStep2;
 
@@ -444,13 +491,15 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
   };
 
   const runKeyTest = async (): Promise<boolean> => {
-    if (provider !== "bedrock" && !apiKey.trim()) return false;
+    if (provider === "openai-compatible" && !baseUrl.trim()) return false;
+    if (provider !== "bedrock" && provider !== "openai-compatible" && !apiKey.trim()) return false;
     setKeyStatus({ state: "testing" });
     try {
       const result = await testLlmKey({
         provider,
         api_key: apiKey.trim(),
         model: effectiveModel,
+        base_url: baseUrl.trim(),
         aws_region: awsRegion.trim(),
         aws_access_key_id: awsAccessKey.trim(),
         aws_secret_access_key: awsSecret.trim(),
@@ -488,6 +537,7 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
           provider,
           api_key: apiKey.trim(),
           model: effectiveModel,
+          base_url: baseUrl.trim(),
           aws_region: awsRegion.trim(),
           aws_access_key_id: awsAccessKey.trim(),
           aws_secret_access_key: awsSecret.trim(),
@@ -572,6 +622,7 @@ export function OnboardingWizard({ onComplete, onDismiss }: WizardProps) {
               model={model}       onModel={setModel}
               customModel={customModel} onCustomModel={setCustomModel}
               apiKey={apiKey}     onApiKey={setApiKey}
+              baseUrl={baseUrl}   onBaseUrl={setBaseUrl}
               awsRegion={awsRegion} onAwsRegion={setAwsRegion}
               awsAccessKey={awsAccessKey} onAwsAccessKey={setAwsAccessKey}
               awsSecret={awsSecret} onAwsSecret={setAwsSecret}

--- a/frontend/src/components/Settings/ModelSection.tsx
+++ b/frontend/src/components/Settings/ModelSection.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Check, Eye, EyeOff, Loader2, X } from "lucide-react";
 import { getLlmSettings, saveLlmSettings, testLlmKey } from "@/api/settings";
 
-type Provider = "anthropic" | "openai" | "google" | "bedrock";
+type Provider = "anthropic" | "openai" | "google" | "bedrock" | "openai-compatible";
 
 // Sentinel value for the "Custom…" radio option on providers (Bedrock) where
 // users commonly need to pin a specific model ID / inference profile.
@@ -29,12 +29,15 @@ const MODELS: Record<Provider, { value: string; label: string; note: string }[]>
     { value: "us.anthropic.claude-haiku-4-5-20251001-v1:0",  label: "Claude Haiku 4.5 (Bedrock)",  note: "Fastest"     },
     { value: CUSTOM_MODEL_VALUE,                              label: "Custom model ID",            note: "Enter your own" },
   ],
+  "openai-compatible": [
+    { value: CUSTOM_MODEL_VALUE, label: "Model name", note: "Set by your proxy" },
+  ],
 };
 
-// Pick a sensible default model when switching providers. For Bedrock we pick
-// the first entry (Sonnet); others use index 1 which is the "Recommended" row.
+// Pick a sensible default model when switching providers. For Bedrock and
+// openai-compatible we pick index 0; others use index 1 ("Recommended" row).
 function defaultModelFor(p: Provider): string {
-  return p === "bedrock" ? MODELS[p][0].value : MODELS[p][1].value;
+  return p === "bedrock" || p === "openai-compatible" ? MODELS[p][0].value : MODELS[p][1].value;
 }
 
 type KeyStatus =
@@ -50,6 +53,7 @@ export function ModelSection() {
   const [model, setModel] = useState(defaultModelFor("anthropic"));
   const [customModel, setCustomModel] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
   // Bedrock-only credential fields.
   const [awsRegion, setAwsRegion] = useState("us-west-2");
   const [awsAccessKey, setAwsAccessKey] = useState("");
@@ -95,20 +99,22 @@ export function ModelSection() {
         if (s.aws_region) setAwsRegion(s.aws_region);
         if (s.has_aws_keys) setHasSavedAwsKeys(true);
         if (s.enable_prompt_cache !== undefined) setEnablePromptCache(s.enable_prompt_cache);
+        if (s.base_url) setBaseUrl(s.base_url);
       })
       .finally(() => setLoading(false));
   }, []);
 
   // Reset key status whenever any credential field changes.
-  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, provider, awsAccessKey, awsSecret, awsRegion, awsSessionToken]);
+  useEffect(() => { setKeyStatus({ state: "idle" }); }, [apiKey, baseUrl, provider, awsAccessKey, awsSecret, awsRegion, awsSessionToken]);
   // Reset save status on any change.
-  useEffect(() => { setSaveStatus("idle"); setError(null); }, [provider, model, customModel, apiKey, awsAccessKey, awsSecret, awsRegion, awsSessionToken, enablePromptCache]);
+  useEffect(() => { setSaveStatus("idle"); setError(null); }, [provider, model, customModel, apiKey, baseUrl, awsAccessKey, awsSecret, awsRegion, awsSessionToken, enablePromptCache]);
 
   const handleProvider = (p: Provider) => {
     setProvider(p);
     setModel(defaultModelFor(p));
     setCustomModel("");
     setApiKey("");
+    setBaseUrl("");
     setAwsAccessKey("");
     setAwsSecret("");
     setAwsSessionToken("");
@@ -119,6 +125,7 @@ export function ModelSection() {
     provider,
     api_key: apiKey.trim(),
     model: effectiveModel,
+    base_url: baseUrl.trim(),
     aws_region: awsRegion.trim(),
     aws_access_key_id: awsAccessKey.trim(),
     aws_secret_access_key: awsSecret.trim(),
@@ -153,7 +160,23 @@ export function ModelSection() {
     }
     setSaveStatus("saving");
     try {
-      if (provider === "bedrock") {
+      if (provider === "openai-compatible") {
+        if (!baseUrl.trim()) {
+          setError("Enter the proxy base URL.");
+          setSaveStatus("error");
+          return;
+        }
+        if (isCustomModel && !customModel.trim()) {
+          setError("Enter a model name.");
+          setSaveStatus("error");
+          return;
+        }
+        // Run a connectivity test if not already verified.
+        if (keyStatus.state !== "ok") {
+          const ok = await runKeyTest();
+          if (!ok) { setSaveStatus("error"); return; }
+        }
+      } else if (provider === "bedrock") {
         // Bedrock: no mandatory field — any save implies "use the default AWS
         // chain if keys are blank". Still run a test if the user hasn't yet.
         if (keyStatus.state !== "ok") {
@@ -175,6 +198,7 @@ export function ModelSection() {
         provider,
         api_key: apiKey.trim(),
         model: effectiveModel,
+        base_url: baseUrl.trim(),
         aws_region: awsRegion.trim(),
         aws_access_key_id: awsAccessKey.trim(),
         aws_secret_access_key: awsSecret.trim(),
@@ -213,10 +237,15 @@ export function ModelSection() {
     ? "Key saved — enter a new one to change"
     : provider === "anthropic" ? "sk-ant-api03-…"
     : provider === "google" ? "AIza…"
+    : provider === "openai-compatible" ? "optional"
     : "sk-proj-…";
 
   const providerLabel = (p: Provider) =>
-    p === "anthropic" ? "Anthropic" : p === "openai" ? "OpenAI" : p === "google" ? "Google" : "AWS Bedrock";
+    p === "anthropic" ? "Anthropic"
+    : p === "openai" ? "OpenAI"
+    : p === "google" ? "Google"
+    : p === "openai-compatible" ? "OpenAI-compatible"
+    : "AWS Bedrock";
 
   return (
     <div className="max-w-lg space-y-8">
@@ -224,7 +253,7 @@ export function ModelSection() {
       <div className="space-y-3">
         <label className="text-sm font-medium text-foreground">Provider</label>
         <div className="flex flex-wrap rounded-xl border border-border p-1 gap-1 w-fit">
-          {(["anthropic", "openai", "google", "bedrock"] as Provider[]).map((p) => (
+          {(["anthropic", "openai", "google", "bedrock", "openai-compatible"] as Provider[]).map((p) => (
             <button
               key={p}
               type="button"
@@ -292,8 +321,52 @@ export function ModelSection() {
         )}
       </div>
 
-      {/* Credentials — either a single API key field OR Bedrock's AWS fields. */}
-      {provider === "bedrock" ? (
+      {/* Credentials — proxy base URL + optional key, single key, or Bedrock AWS fields. */}
+      {provider === "openai-compatible" ? (
+        <div className="space-y-4">
+          <div>
+            <label className="text-sm font-medium text-foreground">Proxy base URL</label>
+            <input
+              type="url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              onBlur={() => { if (baseUrl.trim() && effectiveModel) runKeyTest(); }}
+              placeholder="https://litellm.myorg.com"
+              className="w-full mt-1 bg-background border border-border rounded-xl px-4 py-3
+                         text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                         focus:border-primary/50 placeholder:text-muted-foreground/30"
+            />
+            <p className="text-xs text-muted-foreground/50 mt-1">
+              Any OpenAI-compatible endpoint — LiteLLM, vLLM, Ollama, etc.
+            </p>
+          </div>
+          <div>
+            <label className="text-sm font-medium text-foreground">API key</label>
+            <div className="relative">
+              <input
+                type={showKey ? "text" : "password"}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={hasExistingKey ? "Key saved — enter a new one to change" : "optional"}
+                className="w-full mt-1 bg-background border border-border rounded-xl px-4 py-3
+                           text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/25
+                           focus:border-primary/50 placeholder:text-muted-foreground/30 pr-11"
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey((v) => !v)}
+                className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground/40
+                           hover:text-muted-foreground transition-colors"
+              >
+                {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground/50 mt-1">
+              Leave blank if the proxy requires no authentication.
+            </p>
+          </div>
+        </div>
+      ) : provider === "bedrock" ? (
         <div className="space-y-4">
           <div>
             <label className="text-sm font-medium text-foreground">AWS credentials</label>
@@ -425,10 +498,10 @@ export function ModelSection() {
         </div>
       )}
 
-      {/* Shared verification status + Verify button (Bedrock gets an explicit
-          button since there's no single field to blur off of). */}
+      {/* Shared verification status + Verify button (Bedrock + openai-compatible
+          get an explicit button since there's no single field to blur off of). */}
       <div className="space-y-2">
-        {provider === "bedrock" && (
+        {(provider === "bedrock" || provider === "openai-compatible") && (
           <button
             type="button"
             onClick={runKeyTest}
@@ -436,7 +509,7 @@ export function ModelSection() {
             className="text-sm px-4 py-2 rounded-lg border border-border
                        hover:bg-muted/50 transition-colors disabled:opacity-40"
           >
-            {keyStatus.state === "testing" ? "Verifying…" : "Verify credentials"}
+            {keyStatus.state === "testing" ? "Verifying…" : "Verify connection"}
           </button>
         )}
         {keyStatus.state === "testing" && (

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -24,10 +24,13 @@ from analytics_agent.config import (
 
 # ─── PROVIDER_DEFAULTS structure ─────────────────────────────────────────────
 
-EXPECTED_PROVIDERS = {"anthropic", "openai", "google", "bedrock"}
+EXPECTED_PROVIDERS = {"anthropic", "openai", "google", "bedrock", "openai-compatible"}
 # Providers that authenticate with a single API key (bedrock uses AWS creds instead).
-EXPECTED_API_KEY_PROVIDERS = {"anthropic", "openai", "google"}
+# openai-compatible has an optional key, so it's included here.
+EXPECTED_API_KEY_PROVIDERS = {"anthropic", "openai", "google", "openai-compatible"}
 EXPECTED_TIERS = {"main", "chart", "quality", "delight"}
+# Providers whose default model IDs are intentionally empty (user must supply the model).
+PROVIDERS_WITH_EMPTY_DEFAULTS = {"openai-compatible"}
 
 
 def test_provider_defaults_has_all_providers():
@@ -42,6 +45,8 @@ def test_provider_defaults_all_tiers_present():
 
 def test_provider_defaults_no_empty_values():
     for provider, defaults in PROVIDER_DEFAULTS.items():
+        if provider in PROVIDERS_WITH_EMPTY_DEFAULTS:
+            continue  # these intentionally have empty defaults — user must supply the model
         for tier, model in defaults.items():
             assert model, f"{provider}[{tier}] is empty"
 

--- a/tests/unit/test_openai_compat_proxy.py
+++ b/tests/unit/test_openai_compat_proxy.py
@@ -99,6 +99,7 @@ def proxy_model(mock_proxy_url: str) -> str:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 @contextmanager
 def _patch_settings(base_url: str, api_key: str = "test-key"):
     """Context manager that temporarily redirects the settings singleton to

--- a/tests/unit/test_openai_compat_proxy.py
+++ b/tests/unit/test_openai_compat_proxy.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 import json
 import os
 import threading
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import patch
 
 import pytest
-from contextlib import contextmanager
 
 # ---------------------------------------------------------------------------
 # In-process mock proxy

--- a/tests/unit/test_openai_compat_proxy.py
+++ b/tests/unit/test_openai_compat_proxy.py
@@ -1,0 +1,307 @@
+"""
+Tests for the OpenAI-compatible proxy provider (LiteLLM, vLLM, Ollama, etc.).
+
+Spins up a minimal in-process HTTP server that speaks the OpenAI chat
+completions API, then exercises the full stack:
+
+    settings API (test + save) → LLM factory
+    → ChatOpenAI(base_url=…) → [mock proxy] → parsed AIMessage
+
+No external services required — runs in the standard CI unit-test job.
+
+To run against a real Ollama instance instead of the built-in mock, export:
+    OPENAI_COMPAT_TEST_URL=http://localhost:11434/v1
+    OPENAI_COMPAT_TEST_MODEL=llama3.2:1b
+and run:
+    uv run pytest tests/unit/test_openai_compat_proxy.py -v -s
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+from contextlib import contextmanager
+
+# ---------------------------------------------------------------------------
+# In-process mock proxy
+# ---------------------------------------------------------------------------
+
+_CHAT_RESPONSE = {
+    "id": "chatcmpl-mock",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "mock-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello from mock proxy"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+}
+
+
+class _OpenAICompatHandler(BaseHTTPRequestHandler):
+    """Minimal OpenAI-compatible chat completions endpoint."""
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)  # drain body — we don't validate it
+        body = json.dumps(_CHAT_RESPONSE).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: object) -> None:
+        pass  # suppress per-request noise in test output
+
+
+@pytest.fixture(scope="module")
+def mock_proxy_url() -> str:  # type: ignore[return]
+    """Start a mock OpenAI-compatible server on a free port.
+
+    If OPENAI_COMPAT_TEST_URL is set, that URL is yielded instead so the same
+    tests run against a real proxy (e.g. Ollama) with zero code changes.
+
+    Yields the base URL callers should pass as ``base_url`` (e.g.
+    ``http://127.0.0.1:PORT/v1``).
+    """
+    external = os.environ.get("OPENAI_COMPAT_TEST_URL", "").strip()
+    if external:
+        yield external
+        return
+
+    server = HTTPServer(("127.0.0.1", 0), _OpenAICompatHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}/v1"
+    server.shutdown()
+
+
+@pytest.fixture(scope="module")
+def proxy_model(mock_proxy_url: str) -> str:
+    """Model name to use: real model when testing against Ollama, else 'mock-model'."""
+    if os.environ.get("OPENAI_COMPAT_TEST_URL"):
+        return os.environ.get("OPENAI_COMPAT_TEST_MODEL", "llama3.2:1b")
+    return "mock-model"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _patch_settings(base_url: str, api_key: str = "test-key"):
+    """Context manager that temporarily redirects the settings singleton to
+    the mock proxy and restores it afterwards."""
+    from analytics_agent.config import settings
+
+    saved = (
+        settings.llm_provider,
+        settings.openai_compat_base_url,
+        settings.openai_compat_api_key,
+    )
+    settings.llm_provider = "openai-compatible"
+    settings.openai_compat_base_url = base_url
+    settings.openai_compat_api_key = api_key
+    try:
+        yield settings
+    finally:
+        (
+            settings.llm_provider,
+            settings.openai_compat_base_url,
+            settings.openai_compat_api_key,
+        ) = saved
+
+
+# ---------------------------------------------------------------------------
+# 1. Factory — ChatOpenAI is constructed with the right kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_factory_passes_base_url_and_model(mock_proxy_url: str, proxy_model: str) -> None:
+    """_make_openai_compat must forward base_url and model to ChatOpenAI."""
+    from analytics_agent.config import settings
+
+    settings.openai_compat_base_url = mock_proxy_url
+    settings.openai_compat_api_key = "test-key"
+
+    with patch("langchain_openai.ChatOpenAI") as MockChat:
+        MockChat.return_value = MockChat  # keep the mock callable
+        from analytics_agent.agent.llm import _make_openai_compat
+
+        _make_openai_compat(proxy_model, streaming=False)
+
+    kwargs = MockChat.call_args.kwargs
+    assert kwargs["base_url"] == mock_proxy_url
+    assert kwargs["model"] == proxy_model
+    assert kwargs["temperature"] == 0
+
+
+def test_factory_raises_without_base_url() -> None:
+    """_make_openai_compat must raise clearly when base_url is not configured."""
+    from analytics_agent.config import settings
+
+    saved = settings.openai_compat_base_url
+    settings.openai_compat_base_url = ""
+    try:
+        from analytics_agent.agent.llm import _make_openai_compat
+
+        with pytest.raises(ValueError, match="OPENAI_COMPAT_BASE_URL"):
+            _make_openai_compat("some-model", streaming=False)
+    finally:
+        settings.openai_compat_base_url = saved
+
+
+# ---------------------------------------------------------------------------
+# 2. End-to-end: real HTTP call through the mock proxy
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_returns_response_from_proxy(mock_proxy_url: str, proxy_model: str) -> None:
+    """ChatOpenAI built by the factory must complete a real HTTP round-trip
+    through the (mock or real) proxy and return a non-empty AIMessage."""
+    from analytics_agent.agent.llm import _make_openai_compat
+    from analytics_agent.config import settings
+
+    settings.openai_compat_base_url = mock_proxy_url
+    settings.openai_compat_api_key = "test-key"
+
+    llm = _make_openai_compat(proxy_model, streaming=False)
+    response = llm.invoke("say hello in one word")
+
+    assert response.content, "Expected a non-empty response from the proxy"
+
+
+def test_get_llm_uses_proxy_when_provider_is_set(mock_proxy_url: str, proxy_model: str) -> None:
+    """The public get_llm() accessor must route through the proxy when
+    llm_provider='openai-compatible' and llm_model is set."""
+    from analytics_agent.agent.llm import get_llm
+    from analytics_agent.config import settings
+
+    saved_model = settings.llm_model
+    settings.llm_model = proxy_model
+
+    with _patch_settings(mock_proxy_url):
+        llm = get_llm(streaming=False)
+        response = llm.invoke("ping")
+
+    settings.llm_model = saved_model
+    assert response.content
+
+
+# ---------------------------------------------------------------------------
+# 3. Settings API: /api/settings/llm/test endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_ok_with_proxy(mock_proxy_url: str, proxy_model: str) -> None:
+    """POST /api/settings/llm/test with a reachable proxy must return ok=True."""
+    from analytics_agent.api.settings import TestLlmKeyRequest, test_llm_key
+
+    result = await test_llm_key(
+        TestLlmKeyRequest(
+            provider="openai-compatible",
+            base_url=mock_proxy_url,
+            model=proxy_model,
+            api_key="test-key",
+        )
+    )
+    assert result.ok is True, f"Expected ok=True, got: {result.message}"
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_fails_when_base_url_missing() -> None:
+    """POST /api/settings/llm/test without base_url must return ok=False."""
+    from analytics_agent.api.settings import TestLlmKeyRequest, test_llm_key
+
+    result = await test_llm_key(
+        TestLlmKeyRequest(
+            provider="openai-compatible",
+            base_url="",
+            model="any-model",
+            api_key="test-key",
+        )
+    )
+    assert result.ok is False
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_fails_when_proxy_unreachable() -> None:
+    """POST /api/settings/llm/test pointing at a dead port must return ok=False."""
+    from analytics_agent.api.settings import TestLlmKeyRequest, test_llm_key
+
+    result = await test_llm_key(
+        TestLlmKeyRequest(
+            provider="openai-compatible",
+            base_url="http://127.0.0.1:19999/v1",  # nothing listening here
+            model="any-model",
+            api_key="test-key",
+        )
+    )
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Settings persistence: base_url survives a save → get round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_base_url_reflected_in_get(mock_proxy_url: str, proxy_model: str) -> None:
+    """PUT /api/settings/llm with base_url must update the in-memory singleton
+    so that GET /api/settings/llm returns the same base_url immediately."""
+    from unittest.mock import AsyncMock
+
+    from analytics_agent.api.settings import (
+        UpdateLlmSettingsRequest,
+        get_llm_settings,
+        update_llm_settings,
+    )
+    from analytics_agent.config import settings
+
+    # Capture & restore state so this test is side-effect-free.
+    saved = (
+        settings.llm_provider,
+        settings.llm_model,
+        settings.openai_compat_base_url,
+        settings.openai_compat_api_key,
+    )
+
+    mock_session = AsyncMock()
+    mock_repo = AsyncMock()
+    mock_repo.get.return_value = None  # no pre-existing config
+
+    with patch("analytics_agent.api.settings.SettingsRepo", return_value=mock_repo):
+        await update_llm_settings(
+            UpdateLlmSettingsRequest(
+                provider="openai-compatible",
+                model=proxy_model,
+                base_url=mock_proxy_url,
+                api_key="test-key",
+            ),
+            mock_session,
+        )
+
+        response = await get_llm_settings()
+
+    # Restore singleton before any assertions can fail mid-flight.
+    (
+        settings.llm_provider,
+        settings.llm_model,
+        settings.openai_compat_base_url,
+        settings.openai_compat_api_key,
+    ) = saved
+
+    assert response.provider == "openai-compatible"
+    assert response.base_url == mock_proxy_url


### PR DESCRIPTION
## Summary

- Adds an **"OpenAI-compatible"** provider option so orgs that provision LLM access via a LiteLLM proxy (or vLLM, Ollama, Azure custom endpoint, etc.) can configure the agent without raw provider API keys
- Zero new Python dependencies — routes through the existing `ChatOpenAI` with a user-supplied `base_url`
- API key is optional (some proxies use network-level auth)

## What changed

**Backend**
- `config.py` — new `openai-compatible` entry in provider registries; `openai_compat_base_url` + `openai_compat_api_key` settings fields
- `agent/llm.py` — `_make_openai_compat()` factory registered in `_FACTORIES`
- `api/settings.py` — `base_url` on all LLM request/response models; `openai-compatible` branch in the key-test endpoint; `base_url` persisted + propagated to singleton
- `main.py` — loads `base_url` from DB into settings on startup

**Frontend**
- `ModelSection` + `OnboardingWizard` — new "OpenAI-compatible" tab with Proxy base URL field, optional API key, Verify connection button
- `api/settings.ts` — `base_url` on `LlmSettings`, test, and save payloads

**Tests**
- 8 new tests in `test_openai_compat_proxy.py` using an in-process mock HTTP server; same tests run against real Ollama when `OPENAI_COMPAT_TEST_URL` is set
- New `integration-ollama.yml` CI workflow: path-filtered, runs against `llama3.2:1b` with model weights cached

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/unit/ -v`
- [ ] Ollama integration confirmed locally (8/8 against `llama3.2:1b`)
- [ ] `backend-test` CI job passes (mock server, no external deps)
- [ ] `Integration — OpenAI-compatible proxy` CI job triggers on this PR (files in paths filter changed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)