### PR TITLE
feat: replace crypto.randomUUID() with uuidv4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.4",
+    "uuid": "^14.0.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",
     "vega-lite": "^6.4.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.1
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
       vega:
         specifier: ^6.2.0
         version: 6.2.0
@@ -2067,6 +2070,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   vega-canvas@2.0.0:
     resolution: {integrity: sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==}
@@ -4417,6 +4424,8 @@ snapshots:
       '@types/react': 18.3.28
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.0: {}
 
   vega-canvas@2.0.0: {}
 

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -12,6 +12,7 @@ import { WelcomeView } from "./WelcomeView";
 import { ContextStatusBar } from "./ContextStatusBar";
 import type { UIMessage } from "@/types";
 import { buildUiMessages } from "@/lib/buildUiMessages";
+import { v4 as uuidv4 } from "uuid";
 
 export function ChatView() {
   const {
@@ -149,7 +150,7 @@ export function ChatView() {
           return;
         }
         appendMessage({
-          id: crypto.randomUUID(),
+          id: uuidv4(),
           event_type: "ERROR",
           role: "assistant",
           payload: { error: String(err) },
@@ -208,7 +209,7 @@ export function ChatView() {
 
     // Append user message immediately
     appendMessage({
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       event_type: "TEXT",
       role: "user",
       payload: { text },
@@ -275,7 +276,7 @@ export function ChatView() {
         return;
       }
       appendMessage({
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         event_type: "ERROR",
         role: "assistant",
         payload: { error: String(err) },

--- a/frontend/src/lib/__tests__/buildUiMessages.test.ts
+++ b/frontend/src/lib/__tests__/buildUiMessages.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildUiMessages } from "../buildUiMessages";
+import {v4 as uuidv4} from "uuid";
 import type { MessageRecord } from "@/types";
 
 // Minimal factory so tests only specify what they care about
@@ -7,7 +8,7 @@ function rec(
   overrides: Partial<MessageRecord> & Pick<MessageRecord, "event_type" | "role">
 ): MessageRecord {
   return {
-    id: overrides.id ?? crypto.randomUUID(),
+    id: overrides.id ?? uuidv4(),
     sequence: overrides.sequence ?? 0,
     created_at: overrides.created_at ?? "2024-01-01T00:00:00Z",
     payload: overrides.payload ?? {},

--- a/frontend/src/lib/__tests__/groupMessages.test.ts
+++ b/frontend/src/lib/__tests__/groupMessages.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { groupIntoTurns, shouldShowSeparator, getSepUsage } from "../groupMessages";
+import {v4 as uuidv4} from "uuid";
 import type { UIMessage } from "@/types";
 
 function msg(overrides: Partial<UIMessage> & Pick<UIMessage, "event_type" | "role">): UIMessage {
   return {
-    id: overrides.id ?? crypto.randomUUID(),
+    id: overrides.id ?? uuidv4(),
     payload: overrides.payload ?? {},
     ...overrides,
   };

--- a/frontend/src/store/conversations.ts
+++ b/frontend/src/store/conversations.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { v4 as uuidv4 } from "uuid";
 import type { ConversationSummary, Engine, UIMessage, UsagePayload, TurnUsage } from "@/types";
 
 export interface UsageTotals {
@@ -86,7 +87,7 @@ export const useConversationsStore = create<ConversationsState>((set) => ({
         return { messages: msgs };
       }
       // Create a new TEXT message for this turn (isStreaming=true until marked as thinking or turn ends)
-      const newId = crypto.randomUUID();
+      const newId = uuidv4();
       return {
         streamingTextId: newId,
         messages: [


### PR DESCRIPTION
After deploying an analytics-agengt server on our internal machine, I encountered the `TypeError: crypto.randomUUID is not a function` error.  `crypto.randomUUID()` is only available when running over HTTPS or on localhost, so I want to replace `crypto.randomUUID()` with `uuidv4`.

closes #46