### PR TITLE
fix(ci): bump Node.js to v22 for pnpm v11 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- pnpm@latest is now v11, which requires Node.js >=22.13
- CI was pinned to Node 20, causing Frontend typecheck and E2E jobs to fail with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`
- Bumps both affected jobs (frontend-lint, e2e) from Node 20 → 22

## Test plan
- [ ] Frontend — typecheck & lint passes
- [ ] E2E — Playwright passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)