### PR TITLE
fix: enrich missing engine connection field information from plugin definitions

### DIFF
--- a/backend/src/analytics_agent/api/settings.py
+++ b/backend/src/analytics_agent/api/settings.py
@@ -66,7 +66,7 @@ _MUTATION_TOOL_NAMES = _SKILL_TOOL_NAMES
 
 class ConnectionField(BaseModel):
     key: str
-    label: str
+    label: str | None
     value: str
     sensitive: bool = False
     placeholder: str = ""
@@ -734,7 +734,10 @@ async def list_connections(session: AsyncSession = Depends(get_session)):
                 ]
         else:
             status_str = "unconfigured"
-            fields = []
+            # get fields from conn_cfg.items, set key and value
+            fields = [
+                ConnectionField(key=k, label=None, value=str(v)) for (k, v) in conn_cfg.items()
+            ]
 
         oauth_status = (
             OAuthStatus(

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,6 +1,6 @@
 export interface ConnectionField {
   key: string;
-  label: string;
+  label: string | null;
   value: string;
   sensitive: boolean;
   placeholder: string;

--- a/frontend/src/components/Settings/SettingsModal.tsx
+++ b/frontend/src/components/Settings/SettingsModal.tsx
@@ -74,6 +74,7 @@ import { AddConnectionFlow } from "./connections/AddConnectionFlow";
 import type { NewConnectionPayload, ConnectionPlugin } from "./connections/types";
 import { ModelSection } from "./ModelSection";
 import { AboutSection } from "./AboutSection";
+import {CONNECTION_PLUGINS} from "@/components/Settings/connections";
 
 type Section = "connections" | "model" | "prompt" | "display" | "about";
 
@@ -977,7 +978,26 @@ function ConnectionsSection() {
 
   const CONTEXT_PLATFORM_TYPES = new Set(["datahub", "datahub-mcp"]);
   const datahubConns = connections.filter((c) => CONTEXT_PLATFORM_TYPES.has(c.type));
-  const engineConns = connections.filter((c) => !CONTEXT_PLATFORM_TYPES.has(c.type) && c.type !== "chart");
+  const engineConns = connections.filter((c) => !CONTEXT_PLATFORM_TYPES.has(c.type) && c.type !== "chart")
+      .map(conn =>{
+        // rebuild fields from plugin definition, carrying over stored values
+        const plugin = CONNECTION_PLUGINS.find(p => p.id === conn.type)
+        if (plugin && plugin.fields.length > 0) {
+          conn.fields = plugin.fields.map(pf => {
+            const value = conn.fields.find(f => f.key === pf.key)?.value ?? ""
+            const field: ConnectionField = {
+              key: pf.key,
+              label: pf.label,
+              value: value,
+              sensitive: pf.type === "password",
+              placeholder: pf.placeholder ?? "",
+              secret_key: ""
+            }
+            return field
+          })
+        }
+        return conn
+      })
 
   return (
     <div className="space-y-6">

--- a/frontend/src/components/Settings/connections/helpers.tsx
+++ b/frontend/src/components/Settings/connections/helpers.tsx
@@ -22,6 +22,7 @@ export function createSimplePlugin(spec: SimplePluginSpec): ConnectionPlugin {
     category: spec.category,
     transport: "native",
     description: spec.description,
+    fields: spec.fields,
     icon: spec.icon,
     Form: ({ onDone, onCancel }) => (
       <SimpleFormShell
@@ -93,6 +94,7 @@ export function createMcpStdioPlugin(spec: McpStdioPluginSpec): ConnectionPlugin
     transport: "mcp-stdio",
     description: spec.description,
     icon: spec.icon,
+    fields: fields,
     Form: ({ onDone, onCancel }) => (
       <SimpleFormShell
         fields={fields}
@@ -168,6 +170,7 @@ export function createMcpSsePlugin(spec: McpSsePluginSpec): ConnectionPlugin {
     transport: "mcp-sse",
     description: spec.description,
     icon: spec.icon,
+    fields: fields,
     Form: ({ onDone, onCancel }) => (
       <SimpleFormShell
         fields={fields}

--- a/frontend/src/components/Settings/connections/plugins/bigquery.tsx
+++ b/frontend/src/components/Settings/connections/plugins/bigquery.tsx
@@ -90,5 +90,6 @@ export const bigqueryPlugin: ConnectionPlugin = {
   category: "engine",
   transport: "native",
   description: "Connect to Google BigQuery",
+  fields: FIELDS,
   Form: BigQueryForm,
 };

--- a/frontend/src/components/Settings/connections/plugins/custom-mcp.tsx
+++ b/frontend/src/components/Settings/connections/plugins/custom-mcp.tsx
@@ -8,6 +8,7 @@ export const customMcpEnginePlugin: ConnectionPlugin = {
   category: "engine",
   transport: "mcp-stdio",
   description: "Connect to any MCP-compatible data source",
+  fields: [],
   Form: GenericMcpForm,
 };
 
@@ -18,5 +19,6 @@ export const customMcpContextPlugin: ConnectionPlugin = {
   category: "context_platform",
   transport: "mcp-stdio",
   description: "Connect to any MCP-compatible context platform",
+  fields: [],
   Form: GenericMcpForm,
 };

--- a/frontend/src/components/Settings/connections/plugins/datahub-mcp.tsx
+++ b/frontend/src/components/Settings/connections/plugins/datahub-mcp.tsx
@@ -17,6 +17,25 @@ function normalizeAcrylMcpUrl(raw: string): string {
   return withScheme;
 }
 
+const FIELDS = [
+  {
+    key: "url",
+    label: "MCP server URL",
+    type: "mono" as const,
+    placeholder: "https://<tenant>.acryl.io/integrations/ai/mcp/",
+    required: true,
+    transform: normalizeAcrylMcpUrl,
+  },
+  {
+    key: "token",
+    label: "Access token",
+    type: "password" as const,
+    placeholder: "eyJhbGci…",
+    required: true,
+    hint: "Sent as Authorization: Bearer <token>",
+  },
+]
+
 function DataHubMcpForm({
   onDone,
   onCancel,
@@ -26,24 +45,7 @@ function DataHubMcpForm({
 }) {
   return (
     <SimpleFormShell
-      fields={[
-        {
-          key: "url",
-          label: "MCP server URL",
-          type: "mono",
-          placeholder: "https://<tenant>.acryl.io/integrations/ai/mcp/",
-          required: true,
-          transform: normalizeAcrylMcpUrl,
-        },
-        {
-          key: "token",
-          label: "Access token",
-          type: "password",
-          placeholder: "eyJhbGci…",
-          required: true,
-          hint: "Sent as Authorization: Bearer <token>",
-        },
-      ]}
+      fields={FIELDS}
       onCancel={onCancel}
       onDone={async (payload) => {
         const { url, token, ...rest } = payload.config;
@@ -68,5 +70,6 @@ export const datahubMcpPlugin: ConnectionPlugin = {
   category: "context_platform",
   transport: "mcp-sse",
   description: "Connect to DataHub through its managed MCP server",
+  fields: FIELDS,
   Form: DataHubMcpForm,
 };

--- a/frontend/src/components/Settings/connections/plugins/mysql.tsx
+++ b/frontend/src/components/Settings/connections/plugins/mysql.tsx
@@ -16,6 +16,7 @@ export const mysqlPlugin: ConnectionPlugin = {
   category: "engine",
   transport: "native",
   description: "Connect to a MySQL or MariaDB database",
+  fields: FIELDS,
   Form: ({ onDone, onCancel }) => (
     <SimpleFormShell
       fields={FIELDS}

--- a/frontend/src/components/Settings/connections/plugins/postgresql.tsx
+++ b/frontend/src/components/Settings/connections/plugins/postgresql.tsx
@@ -16,6 +16,7 @@ export const postgresqlPlugin: ConnectionPlugin = {
   category: "engine",
   transport: "native",
   description: "Connect to a PostgreSQL database",
+  fields: FIELDS,
   Form: ({ onDone, onCancel }) => (
     <SimpleFormShell
       fields={FIELDS}

--- a/frontend/src/components/Settings/connections/plugins/snowflake.tsx
+++ b/frontend/src/components/Settings/connections/plugins/snowflake.tsx
@@ -215,5 +215,6 @@ export const snowflakePlugin: ConnectionPlugin = {
   category: "engine",
   transport: "native",
   description: "Direct connection to Snowflake cloud data warehouse",
+  fields: [],
   Form: SnowflakeForm,
 };

--- a/frontend/src/components/Settings/connections/plugins/sqlite.tsx
+++ b/frontend/src/components/Settings/connections/plugins/sqlite.tsx
@@ -13,6 +13,7 @@ export const sqlitePlugin: ConnectionPlugin = {
   category: "engine",
   transport: "native",
   description: "Connect to a local SQLite database file",
+  fields: FIELDS,
   Form: ({ onDone, onCancel }) => (
     <SimpleFormShell
       fields={FIELDS}

--- a/frontend/src/components/Settings/connections/types.ts
+++ b/frontend/src/components/Settings/connections/types.ts
@@ -44,6 +44,7 @@ export interface ConnectionPlugin {
   category: ConnectionCategory;
   transport: ConnectionTransport;
   description: string;
+  fields: FieldDef[];
   icon?: React.ReactNode;
   Form: React.FC<{
     onDone: (payload: NewConnectionPayload) => void;


### PR DESCRIPTION
## Motivation

Currently, Hive data source fields are not displayed on the Data Sources settings page.

closes #52

## Changes

+ Updated `analytics_agent.api.settings.list_connections` to pass through all `conn_cfg.items`
+ Enrich connection fields using plugin fields definitions

## Testing

Before this:
<img width="995" height="208" alt="image" src="https://github.com/user-attachments/assets/135e9273-c3f2-4187-b695-16a5bddda0b0" />

After this:
<img width="828" height="461" alt="image" src="https://github.com/user-attachments/assets/d93261c5-2c0a-47f3-ad86-dfbdd1796a53" />

