### PR TITLE
feat: tab to autocomplete the cycling agent name in onboarding

### DIFF
--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -114,7 +114,14 @@ function Step1Name({ value, onChange, onSubmit }: { value: string; onChange: (v:
             type="text"
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") onSubmit(); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                onSubmit();
+              } else if (e.key === "Tab" && !value) {
+                e.preventDefault();
+                onChange(SAMPLE_NAMES[nameIdx]);
+              }
+            }}
             placeholder=""
             style={{ width: inputWidth, height: "1.15em", lineHeight: 1, padding: 0 }}
             className="inline bg-transparent outline-none border-b-2 border-primary/40


### PR DESCRIPTION
## Summary

Small delight feature on the onboarding wizard.

Step 1 of the wizard (\"Hello! I'm ___, your data analytics agent\") already animates a typewriter cycling through a list of sample agent names — Aria, Nova, Scout, Sage, Atlas, Ember, Iris, Max, Luna, Felix, Zara, Rex. Now pressing **Tab** while the input is empty fills in whichever name is currently on screen. Spot a name you like as it cycles by, tap Tab, and it's yours.

## What changes

A single keydown handler addition in `OnboardingWizard.tsx`:

\`\`\`tsx
} else if (e.key === \"Tab\" && !value) {
  e.preventDefault();
  onChange(SAMPLE_NAMES[nameIdx]);
}
\`\`\`

- Only fires when the input is empty — once the user has typed anything, Tab falls through to default focus behavior.
- Fills with the **full** current name (not the partially-typed prefix), so Tab mid-animation gives you the complete word, matching shell/editor autocomplete conventions.
- The existing typewriter \`useEffect\` already early-returns when \`value\` is truthy, so the carousel naturally stops after autocomplete.

## Test plan
- [ ] Open onboarding wizard step 1, wait for a name to start typing, press Tab — input fills with the full name and the carousel stops.
- [ ] Type some text, then press Tab — focus moves to the next element (default behavior, autocomplete doesn't fire).
- [ ] Clear the input — carousel resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)