### PR TITLE
feat: add sidebar conversation filter

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Plus, Search } from "lucide-react";
 import { useConversationsStore } from "@/store/conversations";
 import { createConversation, deleteConversation } from "@/api/conversations";
 import { ConversationItem } from "./ConversationItem";
@@ -16,18 +17,28 @@ export function Sidebar() {
     removeConversation,
   } = useConversationsStore();
 
+  const [filter, setFilter] = useState("");
+
   const defaultEngine = engines[0]?.name ?? "";
 
   const handleNew = async () => {
     const conv = await createConversation(defaultEngine);
     addConversation(conv);
     setActiveId(conv.id);
+    setFilter("");
   };
 
   const handleDelete = async (id: string) => {
     await deleteConversation(id);
     removeConversation(id);
   };
+
+  const normalizedFilter = filter.trim().toLowerCase();
+  const visibleConversations = normalizedFilter
+    ? conversations.filter((c) =>
+        c.title.toLowerCase().includes(normalizedFilter)
+      )
+    : conversations;
 
   return (
     <aside className="w-64 flex flex-col border-r border-border h-full bg-muted/40">
@@ -49,22 +60,41 @@ export function Sidebar() {
         </button>
       </div>
 
+      {/* Filter */}
+      <div className="px-3 py-2 border-b border-border">
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter conversations…"
+            className="w-full pl-7 pr-2 py-1.5 text-xs bg-background border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary/50 placeholder:text-muted-foreground/40"
+          />
+        </div>
+      </div>
+
       {/* Conversations */}
       <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
-        {conversations.length === 0 && (
+        {conversations.length === 0 ? (
           <p className="text-xs text-muted-foreground px-2 py-4 text-center">
             No conversations yet
           </p>
+        ) : visibleConversations.length === 0 ? (
+          <p className="text-xs text-muted-foreground px-2 py-4 text-center">
+            No matching conversations
+          </p>
+        ) : (
+          visibleConversations.map((conv) => (
+            <ConversationItem
+              key={conv.id}
+              conversation={conv}
+              isActive={conv.id === activeId}
+              onSelect={() => setActiveId(conv.id)}
+              onDelete={() => handleDelete(conv.id)}
+            />
+          ))
         )}
-        {conversations.map((conv) => (
-          <ConversationItem
-            key={conv.id}
-            conversation={conv}
-            isActive={conv.id === activeId}
-            onSelect={() => setActiveId(conv.id)}
-            onDelete={() => handleDelete(conv.id)}
-          />
-        ))}
       </div>
 
       {/* Footer: theme switcher + DataHub badge */}


### PR DESCRIPTION
 ## Summary

  Closes #35. Adds a text filter above the conversation list in the sidebar — type to narrow the list by title (case-insensitive substring match).

  Per the issue's stretch goal, the filter clears automatically when a new conversation is started.

  ## What changes

  Single component (`frontend/src/components/Sidebar/Sidebar.tsx`):
  - Local `useState` for the filter string (kept out of Zustand — sidebar is the only consumer)
  - `<input>` with a Search icon, styled to match existing form inputs (`focus:ring-primary/50`, `placeholder:text-muted-foreground/40`)
  - `handleNew` resets the filter after creating a new conversation
  - Empty states split into two: "No conversations yet" (list empty) vs "No matching conversations" (filter active, no hits)

  ## Test plan

  - [ ] Type into the filter — list narrows in real time
  - [ ] Type something that matches nothing — see "No matching conversations"
  - [ ] Clear the filter — full list returns
  - [ ] Click + (new conversation) while a filter is active — filter clears, new conversation opens
  - [ ] Delete a conversation while filtering — remaining matches stay; active-conversation behavior unaffected