### PR TITLE
feat(db): configurable connection pool tuning for MySQL / PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ DATABASE_URL=sqlite+aiosqlite:///./data/dev.db
 # DB_POOL_RECYCLE=1800
 # DB_POOL_PRE_PING=true
 # DB_POOL_TIMEOUT=10
+# asyncpg only: per-statement timeout (s) so a wedged connection's pre-ping
+# fails fast instead of hanging forever. 0 disables.
+# DB_COMMAND_TIMEOUT=30
 
 # Engine config
 ENGINES_CONFIG=./config.yaml

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,15 @@ AWS_REGION=us-west-2
 # SQLite (local dev):
 DATABASE_URL=sqlite+aiosqlite:///./data/dev.db
 
+# Connection pool tuning — applied to MySQL / PostgreSQL only (SQLite ignored).
+# DB_POOL_PRE_PING is required for asyncpg: connections broken by task
+# cancellation otherwise remain pooled and stall the next checkout.
+# DB_POOL_SIZE=10
+# DB_MAX_OVERFLOW=20
+# DB_POOL_RECYCLE=1800
+# DB_POOL_PRE_PING=true
+# DB_POOL_TIMEOUT=10
+
 # Engine config
 ENGINES_CONFIG=./config.yaml
 SQL_ROW_LIMIT=500

--- a/backend/src/analytics_agent/config.py
+++ b/backend/src/analytics_agent/config.py
@@ -245,6 +245,15 @@ class Settings(BaseSettings):
     # Database — defaults to the user config dir; override via DATABASE_URL env var
     database_url: str = f"sqlite+aiosqlite:///{_CONFIG_DIR}/data/agent.db"
 
+    # Connection pool — applied only to non-SQLite engines (MySQL / PostgreSQL).
+    # pool_pre_ping is critical for asyncpg: without it, a connection broken by
+    # task cancellation stays in the pool and the next checkout hangs forever.
+    db_pool_size: int = 10
+    db_max_overflow: int = 20
+    db_pool_recycle: int = 1800
+    db_pool_pre_ping: bool = True
+    db_pool_timeout: int = 10
+
     # Engine config — defaults to the user config dir; override via ENGINES_CONFIG env var
     engines_config: str = str(_CONFIG_DIR / "config.yaml")
     sql_row_limit: int = 500

--- a/backend/src/analytics_agent/config.py
+++ b/backend/src/analytics_agent/config.py
@@ -253,6 +253,10 @@ class Settings(BaseSettings):
     db_pool_recycle: int = 1800
     db_pool_pre_ping: bool = True
     db_pool_timeout: int = 10
+    # asyncpg only: per-statement timeout (seconds) applied via connect_args so
+    # pool_pre_ping's SELECT 1 on a wedged connection fails fast instead of
+    # blocking forever. 0 disables. Ignored for SQLite / MySQL.
+    db_command_timeout: int = 30
 
     # Engine config — defaults to the user config dir; override via ENGINES_CONFIG env var
     engines_config: str = str(_CONFIG_DIR / "config.yaml")

--- a/backend/src/analytics_agent/db/base.py
+++ b/backend/src/analytics_agent/db/base.py
@@ -15,9 +15,18 @@ def _get_engine():
     if _engine is None:
         url = settings.database_url
         is_sqlite = "sqlite" in url
+        is_asyncpg = "asyncpg" in url
+        connect_args: dict = {}
+        if is_sqlite:
+            connect_args = {"check_same_thread": False}
+        elif is_asyncpg and settings.db_command_timeout > 0:
+            # Bound every statement (including pool_pre_ping's SELECT 1) so a
+            # connection wedged by task cancellation fails fast instead of
+            # hanging the next checkout forever.
+            connect_args = {"command_timeout": settings.db_command_timeout}
         kwargs: dict = {
             "echo": settings.log_level == "DEBUG",
-            "connect_args": {"check_same_thread": False} if is_sqlite else {},
+            "connect_args": connect_args,
         }
         if not is_sqlite:
             kwargs.update(

--- a/backend/src/analytics_agent/db/base.py
+++ b/backend/src/analytics_agent/db/base.py
@@ -13,11 +13,21 @@ _AsyncSessionFactory = None
 def _get_engine():
     global _engine, _AsyncSessionFactory
     if _engine is None:
-        _engine = create_async_engine(
-            settings.database_url,
-            echo=settings.log_level == "DEBUG",
-            connect_args={"check_same_thread": False} if "sqlite" in settings.database_url else {},
-        )
+        url = settings.database_url
+        is_sqlite = "sqlite" in url
+        kwargs: dict = {
+            "echo": settings.log_level == "DEBUG",
+            "connect_args": {"check_same_thread": False} if is_sqlite else {},
+        }
+        if not is_sqlite:
+            kwargs.update(
+                pool_size=settings.db_pool_size,
+                max_overflow=settings.db_max_overflow,
+                pool_recycle=settings.db_pool_recycle,
+                pool_pre_ping=settings.db_pool_pre_ping,
+                pool_timeout=settings.db_pool_timeout,
+            )
+        _engine = create_async_engine(url, **kwargs)
         _AsyncSessionFactory = async_sessionmaker(_engine, expire_on_commit=False)
     return _engine
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -163,6 +163,7 @@ def _clear_pool_env(monkeypatch):
         "DB_POOL_RECYCLE",
         "DB_POOL_PRE_PING",
         "DB_POOL_TIMEOUT",
+        "DB_COMMAND_TIMEOUT",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -175,6 +176,7 @@ def test_db_pool_settings_defaults(monkeypatch):
     assert settings.db_pool_recycle == 1800
     assert settings.db_pool_pre_ping is True
     assert settings.db_pool_timeout == 10
+    assert settings.db_command_timeout == 30
 
 
 def test_db_pool_settings_env_override(monkeypatch):
@@ -185,9 +187,11 @@ def test_db_pool_settings_env_override(monkeypatch):
     monkeypatch.setenv("DB_POOL_RECYCLE", "900")
     monkeypatch.setenv("DB_POOL_PRE_PING", "false")
     monkeypatch.setenv("DB_POOL_TIMEOUT", "5")
+    monkeypatch.setenv("DB_COMMAND_TIMEOUT", "15")
     settings = Settings(_env_file=None)
     assert settings.db_pool_size == 25
     assert settings.db_max_overflow == 50
     assert settings.db_pool_recycle == 900
     assert settings.db_pool_pre_ping is False
     assert settings.db_pool_timeout == 5
+    assert settings.db_command_timeout == 15

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -149,3 +149,45 @@ def test_load_engines_config_substitutes_env_vars(tmp_path, monkeypatch):
     assert len(engines) == 1
     assert engines[0].connection["account"] == "xy12345"
     assert engines[0].connection["user"] == "test_user"
+
+
+# ---------------------------------------------------------------------------
+# Connection pool settings (PR #72)
+# ---------------------------------------------------------------------------
+
+
+def _clear_pool_env(monkeypatch):
+    for var in (
+        "DB_POOL_SIZE",
+        "DB_MAX_OVERFLOW",
+        "DB_POOL_RECYCLE",
+        "DB_POOL_PRE_PING",
+        "DB_POOL_TIMEOUT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_db_pool_settings_defaults(monkeypatch):
+    _clear_pool_env(monkeypatch)
+    settings = Settings(_env_file=None)
+    assert settings.db_pool_size == 10
+    assert settings.db_max_overflow == 20
+    assert settings.db_pool_recycle == 1800
+    assert settings.db_pool_pre_ping is True
+    assert settings.db_pool_timeout == 10
+
+
+def test_db_pool_settings_env_override(monkeypatch):
+    """Ints and the bool flag coerce correctly from env-var strings."""
+    _clear_pool_env(monkeypatch)
+    monkeypatch.setenv("DB_POOL_SIZE", "25")
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "50")
+    monkeypatch.setenv("DB_POOL_RECYCLE", "900")
+    monkeypatch.setenv("DB_POOL_PRE_PING", "false")
+    monkeypatch.setenv("DB_POOL_TIMEOUT", "5")
+    settings = Settings(_env_file=None)
+    assert settings.db_pool_size == 25
+    assert settings.db_max_overflow == 50
+    assert settings.db_pool_recycle == 900
+    assert settings.db_pool_pre_ping is False
+    assert settings.db_pool_timeout == 5

--- a/tests/unit/test_db_pool_engine.py
+++ b/tests/unit/test_db_pool_engine.py
@@ -23,7 +23,7 @@ _POOL_KWARGS = {
 }
 
 
-def _fake_settings(database_url: str) -> SimpleNamespace:
+def _fake_settings(database_url: str, command_timeout: int = 30) -> SimpleNamespace:
     return SimpleNamespace(
         database_url=database_url,
         log_level="INFO",
@@ -32,15 +32,16 @@ def _fake_settings(database_url: str) -> SimpleNamespace:
         db_pool_recycle=1800,
         db_pool_pre_ping=True,
         db_pool_timeout=10,
+        db_command_timeout=command_timeout,
     )
 
 
-def _call_get_engine(database_url: str):
+def _call_get_engine(database_url: str, command_timeout: int = 30):
     """Reset the module singletons and capture the create_async_engine call."""
     with (
         patch.object(db_base, "_engine", None),
         patch.object(db_base, "_AsyncSessionFactory", None),
-        patch.object(db_base, "settings", _fake_settings(database_url)),
+        patch.object(db_base, "settings", _fake_settings(database_url, command_timeout)),
         patch.object(db_base, "create_async_engine", MagicMock()) as mock_create,
         patch.object(db_base, "async_sessionmaker", MagicMock()),
     ):
@@ -55,17 +56,25 @@ def test_sqlite_engine_omits_pool_kwargs():
     assert kwargs["connect_args"] == {"check_same_thread": False}
 
 
-def test_postgres_engine_applies_pool_kwargs():
+def test_postgres_engine_applies_pool_kwargs_and_command_timeout():
     args, kwargs = _call_get_engine("postgresql+asyncpg://u:p@host/db")
     assert kwargs["pool_size"] == 10
     assert kwargs["max_overflow"] == 20
     assert kwargs["pool_recycle"] == 1800
     assert kwargs["pool_pre_ping"] is True
     assert kwargs["pool_timeout"] == 10
+    # asyncpg gets a per-statement timeout so a wedged pre-ping fails fast.
+    assert kwargs["connect_args"] == {"command_timeout": 30}
+
+
+def test_postgres_command_timeout_disabled_when_zero():
+    args, kwargs = _call_get_engine("postgresql+asyncpg://u:p@host/db", command_timeout=0)
     assert kwargs["connect_args"] == {}
+    assert _POOL_KWARGS.issubset(kwargs)
 
 
-def test_mysql_engine_applies_pool_kwargs():
+def test_mysql_engine_applies_pool_kwargs_without_command_timeout():
+    """command_timeout is asyncpg-specific; MySQL must not receive it."""
     args, kwargs = _call_get_engine("mysql+asyncmy://u:p@host/db")
     assert _POOL_KWARGS.issubset(kwargs)
     assert kwargs["connect_args"] == {}

--- a/tests/unit/test_db_pool_engine.py
+++ b/tests/unit/test_db_pool_engine.py
@@ -1,0 +1,71 @@
+"""
+Tests for connection-pool wiring in db.base._get_engine (PR #72).
+
+Verifies the branch that gates pool kwargs on engine type:
+  - SQLite engines must NOT receive pool_size/pre_ping/etc. (the default
+    SQLite pool rejects those args), and keep check_same_thread=False.
+  - MySQL / PostgreSQL engines must receive the five configured pool knobs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import analytics_agent.db.base as db_base
+
+_POOL_KWARGS = {
+    "pool_size",
+    "max_overflow",
+    "pool_recycle",
+    "pool_pre_ping",
+    "pool_timeout",
+}
+
+
+def _fake_settings(database_url: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        database_url=database_url,
+        log_level="INFO",
+        db_pool_size=10,
+        db_max_overflow=20,
+        db_pool_recycle=1800,
+        db_pool_pre_ping=True,
+        db_pool_timeout=10,
+    )
+
+
+def _call_get_engine(database_url: str):
+    """Reset the module singletons and capture the create_async_engine call."""
+    with (
+        patch.object(db_base, "_engine", None),
+        patch.object(db_base, "_AsyncSessionFactory", None),
+        patch.object(db_base, "settings", _fake_settings(database_url)),
+        patch.object(db_base, "create_async_engine", MagicMock()) as mock_create,
+        patch.object(db_base, "async_sessionmaker", MagicMock()),
+    ):
+        db_base._get_engine()
+    assert mock_create.call_count == 1
+    return mock_create.call_args
+
+
+def test_sqlite_engine_omits_pool_kwargs():
+    args, kwargs = _call_get_engine("sqlite+aiosqlite:///./data/dev.db")
+    assert _POOL_KWARGS.isdisjoint(kwargs)
+    assert kwargs["connect_args"] == {"check_same_thread": False}
+
+
+def test_postgres_engine_applies_pool_kwargs():
+    args, kwargs = _call_get_engine("postgresql+asyncpg://u:p@host/db")
+    assert kwargs["pool_size"] == 10
+    assert kwargs["max_overflow"] == 20
+    assert kwargs["pool_recycle"] == 1800
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["pool_timeout"] == 10
+    assert kwargs["connect_args"] == {}
+
+
+def test_mysql_engine_applies_pool_kwargs():
+    args, kwargs = _call_get_engine("mysql+asyncmy://u:p@host/db")
+    assert _POOL_KWARGS.issubset(kwargs)
+    assert kwargs["connect_args"] == {}


### PR DESCRIPTION
## Why

  Without `pool_pre_ping=True`, `asyncpg` leaves connections that were
  interrupted by task cancellation (CancelledError) in a half-broken
  state inside the SQLAlchemy pool. The next checkout of such a
  connection hangs indefinitely, which under concurrent load presents
  as the whole app stalling — even though no obvious error surfaces.

  The default `AsyncAdaptedQueuePool` (pool_size=5, max_overflow=10,
  pool_timeout=30s) is also too small for production deployments and
  provides no recycle behavior to survive managed-PG idle timeouts.

  ## What
  
  Expose the standard SQLAlchemy pool knobs via env vars, applied to
  non-SQLite engines only:

  | Env var | Default | Purpose |
  |---|---|---|
  | `DB_POOL_SIZE` | 10 | Persistent pool size |
  | `DB_MAX_OVERFLOW` | 20 | Burst capacity |
  | `DB_POOL_PRE_PING` | true | Detect broken connections on checkout (asyncpg critical) |
  | `DB_POOL_TIMEOUT` | 10 | Fail-fast under load (SQLA default 30s "hangs") |

  SQLite path is unchanged.

  ## Test

  - Unit: settings load with defaults, env-var override verified
  - Manual: previously-reproducible asyncpg hang under concurrent SSE
    agent execution no longer occurs after enabling `pool_pre_ping`