### PR TITLE
Fix/quickstart demo flow

### DIFF
--- a/backend/src/analytics_agent/quickstart.py
+++ b/backend/src/analytics_agent/quickstart.py
@@ -560,16 +560,20 @@ def _ingest_metadata(gms_token: str) -> None:
 
 
 def _write_demo_config(config_dir: Path, gms_token: str, llm_env: dict[str, str]) -> None:
-    """Write .env and config.yaml for the demo (DataHub + Olist MySQL)."""
+    """Write .env and config.yaml for the demo (DataHub + MySQL)."""
     import shutil
+
+    # The agent runs natively on the host, so MySQL and DataHub GMS are
+    # reachable via localhost even though they run inside Docker containers.
+    _demo_host = "localhost"
 
     # .env
     env_updates: dict[str, str] = {
-        "DATAHUB_GMS_URL": f"http://{_HOST_INTERNAL}:8080",
+        "DATAHUB_GMS_URL": f"http://{_demo_host}:8080",
         "DATAHUB_GMS_TOKEN": gms_token,
         "DATABASE_URL": (
             f"mysql+aiomysql://{_DEMO_MYSQL_USER}:{_DEMO_MYSQL_PASS}"
-            f"@{_HOST_INTERNAL}:{_DEMO_MYSQL_PORT}/talkster"
+            f"@{_demo_host}:{_DEMO_MYSQL_PORT}/talkster"
         ),
         "DISABLE_NEWER_GMS_FIELD_DETECTION": "true",
     }
@@ -582,7 +586,7 @@ def _write_demo_config(config_dir: Path, gms_token: str, llm_env: dict[str, str]
     shutil.copy(src, dest)
     # Patch host references in the copied config
     text = dest.read_text()
-    text = text.replace("${MYSQL_HOST}", _HOST_INTERNAL)
+    text = text.replace("${MYSQL_HOST}", _demo_host)
     dest.write_text(text)
 
     click.echo(f"  ✓ Demo config written to {config_dir}/")

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -57,6 +57,7 @@ check_cmd docker       "Install Docker Desktop: https://www.docker.com/products/
 check_cmd datahub      "Install DataHub CLI: pip install acryl-datahub"
 check_cmd uv           "Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh"
 check_cmd python3      "Install Python 3.11+: https://python.org"
+check_cmd openssl      "Install OpenSSL: https://openssl.org (needed to generate DataHub signing keys)"
 # pnpm not required — the Docker image builds the frontend internally
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -264,6 +264,10 @@ if _gms_healthy; then
 else
     go "No DataHub GMS found at ${DATAHUB_GMS_URL} — starting DataHub OSS quickstart..."
 
+    # DataHub v1.5+ requires these to be non-empty; auto-generate if not set.
+    export DATAHUB_TOKEN_SERVICE_SIGNING_KEY="${DATAHUB_TOKEN_SERVICE_SIGNING_KEY:-$(openssl rand -hex 32)}"
+    export DATAHUB_TOKEN_SERVICE_SALT="${DATAHUB_TOKEN_SERVICE_SALT:-$(openssl rand -hex 16)}"
+
     # ── Optional: enable semantic search if OPENAI_API_KEY is available ───────
     # Semantic search requires GMS to receive extra env vars that the default
     # quickstart compose does not include. We inject them via a compose override

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -438,6 +438,8 @@ DATABASE_URL=mysql+aiomysql://${MYSQL_USER}:${MYSQL_PASSWORD}@host.docker.intern
 # acryl stack sets this, causing it to enable cloud-only ES fields that fail.
 # Force OSS mode so GraphQL queries use the correct field set.
 DISABLE_NEWER_GMS_FIELD_DETECTION=true
+# Point the agent at the config.yaml mounted into the container.
+ENGINES_CONFIG=/app/config.yaml
 EOF
 
 # Append LLM key if one was found in the environment — otherwise the wizard handles it


### PR DESCRIPTION
## Summary

- Auto-generate DataHub token signing keys so fresh installs work with DataHub v1.5.0.6+
- Add ENGINES_CONFIG to .env.quickstart so the Docker agent reads the mounted config.yaml
- Use localhost instead of host.docker.internal in quickstart --demo native flow

## Test plan

- [x] Fresh `bash quickstart.sh` completes without signing key error
- [x] Agent at http://localhost:8100 shows the demo engine connected after setup
- [x] `analytics-agent quickstart --demo` connects to MySQL on all platforms