### PR TITLE
chore: gitignore local test/session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ backend/src/analytics_agent/static/
 *.log
 nohup.out
 
-# Playwright MCP test artifacts
+# Playwright test artifacts
 .playwright-mcp/
 *.png
+# Playwright default output dir (traces, .last-run.json)
+test-results/
+# Personal dev configs pointing at an already-running server
+tests/e2e/*.local.config.ts
+
+# Claude Code session state (local-only)
+.claude/


### PR DESCRIPTION
## What

Add three ignore rules so local-only files stop appearing as untracked in `git status`:

- `test-results/` — Playwright's default output dir (traces, `.last-run.json`)
- `tests/e2e/*.local.config.ts` — personal dev configs that point at an already-running server
- `.claude/` — Claude Code session state

## Why

These are machine-local artifacts, not project source. They were accumulating as untracked noise. Comments are on their own lines since `.gitignore` doesn't support inline `#` comments.

No source or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)