### PR TITLE
chore: gitignore .git-credentials for agent tooling clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ tests/e2e/*.local.config.ts
 
 # Claude Code session state (local-only)
 .claude/
+
+# Git credentials (written by DataHub agent tooling for auth; never commit)
+.git-credentials


### PR DESCRIPTION
## What

Add `.git-credentials` to the root `.gitignore`.

## Why

DataHub's agent tooling (e.g. the Otto/Bart code-archaeology assistant) clones repos to answer source-level questions. For auth it writes a `.git-credentials` file, and as a safety guard it **refuses to clone any repo whose root `.gitignore` does not list `.git-credentials`** — this guarantees the credential file can never be accidentally committed.

`datahub-project/datahub` already satisfies this (its `.gitignore` includes `.git-credentials`). Adding the same one line here lets the assistant read this repo so it can answer community questions about the analytics-agent from source, not just docs.

## Impact

- One line added to `.gitignore`; no functional/code changes.
- Purely defensive — ensures a local-only credentials file is never tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3ckwD4fGGeEdxHJWBsS1T
