### PR TITLE
fix(frontend): virtualize chat message list to bound memory on long conversations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-tooltip": "^1.1.3",
+    "@tanstack/react-virtual": "^3.14.6",
     "clsx": "^2.1.1",
     "lucide-react": "^0.453.0",
     "react": "^18.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.3
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.6
+        version: 3.14.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -649,6 +652,15 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tanstack/react-virtual@3.14.6':
+    resolution: {integrity: sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.4':
+    resolution: {integrity: sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -760,6 +772,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -2810,6 +2823,14 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/react-virtual@3.14.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/virtual-core@3.17.4': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -181,27 +181,38 @@ export function ChatView() {
   const [showReasoning, setShowReasoning] = useState(true);
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [exportIncludeReasoning, setExportIncludeReasoning] = useState(false);
+  // While true, MessageList renders the full transcript unvirtualized so
+  // window.print() captures every turn (not just the on-screen ones).
+  const [printing, setPrinting] = useState(false);
 
   const handleExport = useCallback(() => {
-    document.querySelectorAll("[data-print-expand]").forEach((el) => {
-      (el as HTMLElement).style.maxHeight = "none";
-      (el as HTMLElement).style.overflow = "visible";
-      (el as HTMLElement).style.opacity = "1";
-    });
+    // Switch MessageList out of virtualization first, then wait two frames so
+    // the full transcript is painted before we snapshot it for print.
+    setPrinting(true);
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        document.querySelectorAll("[data-print-expand]").forEach((el) => {
+          (el as HTMLElement).style.maxHeight = "none";
+          (el as HTMLElement).style.overflow = "visible";
+          (el as HTMLElement).style.opacity = "1";
+        });
 
-    const slugify = (s: string) =>
-      s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+        const slugify = (s: string) =>
+          s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 
-    const appName = slugify(useDisplayStore.getState().appName || "analytics-agent");
-    const title   = slugify(activeConv?.title ?? "conversation");
-    const ts      = new Date().toISOString().slice(0, 16).replace("T", "-").replace(":", "");
-    const filename = `${appName}-${title}-${ts}`;
+        const appName = slugify(useDisplayStore.getState().appName || "analytics-agent");
+        const title   = slugify(activeConv?.title ?? "conversation");
+        const ts      = new Date().toISOString().slice(0, 16).replace("T", "-").replace(":", "");
+        const filename = `${appName}-${title}-${ts}`;
 
-    const prev = document.title;
-    document.title = filename;
-    window.print();
-    document.title = prev;
-    setExportModalOpen(false);
+        const prev = document.title;
+        document.title = filename;
+        window.print();
+        document.title = prev;
+        setPrinting(false);
+        setExportModalOpen(false);
+      })
+    );
   }, [activeConv?.title]);
 
   const handleSend = async (text: string) => {
@@ -360,6 +371,7 @@ export function ChatView() {
         messages={messages}
         isStreaming={isStreaming}
         showReasoning={showReasoning}
+        printing={printing}
         onChartError={(error) => {
           if (chartErrorRetried.current || isStreaming) return;
           chartErrorRetried.current = true;

--- a/frontend/src/components/Chat/MessageList.tsx
+++ b/frontend/src/components/Chat/MessageList.tsx
@@ -1,23 +1,106 @@
-import { Fragment, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { UIMessage } from "@/types";
 import { TextMessage } from "./messages/TextMessage";
 import { AgentWorkBlock } from "./messages/AgentWorkBlock";
 import { ChartMessage } from "./messages/ChartMessage";
-import { groupIntoTurns } from "@/lib/groupMessages";
+import { groupIntoTurns, type TurnGroup } from "@/lib/groupMessages";
 
 interface Props {
   messages: UIMessage[];
   isStreaming?: boolean;
   showReasoning?: boolean;
   onChartError?: (error: string) => void;
+  /**
+   * Render every turn in normal document flow instead of virtualizing.
+   * Set by ChatView during PDF export so the whole transcript is in the DOM
+   * and the `@media print` rules (which target `#chat-messages > [data-print-role]`)
+   * still apply. Off for the interactive view, which virtualizes to stay bounded.
+   */
+  printing?: boolean;
 }
 
-export function MessageList({ messages, isStreaming = false, showReasoning = true, onChartError }: Props) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+/** The visible content of one turn. Shared by the virtualized and print paths. */
+function TurnContent({
+  group,
+  showReasoning,
+  onChartError,
+}: {
+  group: TurnGroup;
+  showReasoning: boolean;
+  onChartError?: (error: string) => void;
+}) {
+  return (
+    <>
+      {/* User message */}
+      {group.userMsg && (
+        <div className="flex flex-col items-end" data-print-role="user">
+          <TextMessage payload={group.userMsg.payload as never} role="user" isStreaming={false} />
+        </div>
+      )}
 
+      {/* Agent work block — tool calls, SQL, thinking. Charts are excluded. */}
+      {group.workMsgs.length > 0 && (
+        <AgentWorkBlock
+          workMessages={group.workMsgs}
+          turnUsage={group.finalMsg?.turnUsage}
+          isStreaming={group.isActivelyStreaming}
+          showReasoning={showReasoning}
+          onChartError={onChartError}
+        />
+      )}
+
+      {/* Charts rendered OUTSIDE the work block so they stay visible when it collapses. */}
+      {group.chartMsgs.map((msg) => (
+        <div key={msg.id} className="w-full" data-print-role="chart">
+          <ChartMessage payload={msg.payload as never} onRenderError={onChartError} />
+        </div>
+      ))}
+
+      {/* Final visible response */}
+      {group.finalMsg && (group.finalMsg.payload as { text?: string }).text?.trim() && (
+        <div className="flex flex-col items-start" data-print-role="assistant">
+          <TextMessage
+            payload={group.finalMsg.payload as never}
+            role="assistant"
+            isStreaming={group.finalMsg.isStreaming}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export function MessageList({
+  messages,
+  isStreaming = false,
+  showReasoning = true,
+  onChartError,
+  printing = false,
+}: Props) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  // Whether the user is pinned to the bottom. Starts true so a freshly opened
+  // conversation lands on the latest turn; flipped off once they scroll up to
+  // read history, so streaming/new turns don't yank them back down.
+  const atBottomRef = useRef(true);
+
+  const groups = messages.length > 0 ? groupIntoTurns(messages, isStreaming) : [];
+
+  const virtualizer = useVirtualizer({
+    count: groups.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 140,
+    overscan: 6,
+    getItemKey: (index) => groups[index].key,
+  });
+
+  // Keep the newest turn in view while the user is at the bottom — covers both
+  // a new turn arriving and the final message growing token-by-token during
+  // streaming (`messages` identity changes on each streamed chunk).
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+    if (printing || !atBottomRef.current || groups.length === 0) return;
+    virtualizer.scrollToIndex(groups.length - 1, { align: "end" });
+  }, [messages, groups.length, printing, virtualizer]);
 
   if (messages.length === 0) {
     return (
@@ -27,57 +110,60 @@ export function MessageList({ messages, isStreaming = false, showReasoning = tru
     );
   }
 
-  const groups = groupIntoTurns(messages, isStreaming);
+  // Print path: full transcript in normal flow, so the existing @media print
+  // CSS (direct-child `data-print-role` selectors) works unchanged.
+  if (printing) {
+    return (
+      <div id="chat-messages" className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {groups.map((group) => (
+          <div key={group.key} className="space-y-3">
+            <TurnContent group={group} showReasoning={showReasoning} onChartError={onChartError} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const handleScroll = () => {
+    const el = parentRef.current;
+    if (!el) return;
+    // 80px of slack: "near the bottom" still counts as pinned.
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  };
 
   return (
-    <div id="chat-messages" className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
-      {groups.map((group) => (
-        <Fragment key={group.key}>
-          {/* User message */}
-          {group.userMsg && (
-            <div className="flex flex-col items-end" data-print-role="user">
-              <TextMessage
-                payload={group.userMsg.payload as never}
-                role="user"
-                isStreaming={false}
+    <div
+      id="chat-messages"
+      ref={parentRef}
+      onScroll={handleScroll}
+      className="flex-1 overflow-y-auto px-4 py-4"
+    >
+      <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+        {virtualizer.getVirtualItems().map((item) => (
+          <div
+            key={item.key}
+            data-index={item.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${item.start}px)`,
+            }}
+          >
+            {/* pb-3 reproduces the old `space-y-3` gap; it lives inside the
+                measured element so each row's height includes the gap. */}
+            <div className="pb-3 space-y-3">
+              <TurnContent
+                group={groups[item.index]}
+                showReasoning={showReasoning}
+                onChartError={onChartError}
               />
             </div>
-          )}
-
-          {/* Agent work block — tool calls, SQL, thinking. Charts are excluded. */}
-          {group.workMsgs.length > 0 && (
-            <AgentWorkBlock
-              workMessages={group.workMsgs}
-              turnUsage={group.finalMsg?.turnUsage}
-              isStreaming={group.isActivelyStreaming}
-              showReasoning={showReasoning}
-              onChartError={onChartError}
-            />
-          )}
-
-          {/* Charts rendered OUTSIDE the work block so they stay visible when it collapses. */}
-          {group.chartMsgs.map((msg) => (
-            <div key={msg.id} className="w-full" data-print-role="chart">
-              <ChartMessage
-                payload={msg.payload as never}
-                onRenderError={onChartError}
-              />
-            </div>
-          ))}
-
-          {/* Final visible response */}
-          {group.finalMsg && (group.finalMsg.payload as { text?: string }).text?.trim() && (
-            <div className="flex flex-col items-start" data-print-role="assistant">
-              <TextMessage
-                payload={group.finalMsg.payload as never}
-                role="assistant"
-                isStreaming={group.finalMsg.isStreaming}
-              />
-            </div>
-          )}
-        </Fragment>
-      ))}
-      <div ref={bottomRef} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Chat/MessageList.tsx
+++ b/frontend/src/components/Chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { Fragment, useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { UIMessage } from "@/types";
 import { TextMessage } from "./messages/TextMessage";
@@ -114,11 +114,16 @@ export function MessageList({
   // CSS (direct-child `data-print-role` selectors) works unchanged.
   if (printing) {
     return (
+      // Fragment (not a wrapping div) keeps each turn's `data-print-role`
+      // elements as *direct* children of #chat-messages, so the @media print
+      // rules `#chat-messages > [data-print-role]` still match. The container's
+      // own `space-y-3` supplies the inter-element gap, as in the pre-virtualized
+      // version.
       <div id="chat-messages" className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
         {groups.map((group) => (
-          <div key={group.key} className="space-y-3">
+          <Fragment key={group.key}>
             <TurnContent group={group} showReasoning={showReasoning} onChartError={onChartError} />
-          </div>
+          </Fragment>
         ))}
       </div>
     );

--- a/frontend/src/components/Chat/messages/ChartMessage.tsx
+++ b/frontend/src/components/Chat/messages/ChartMessage.tsx
@@ -9,6 +9,10 @@ interface Props {
 
 export function ChartMessage({ payload, onRenderError }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  // Holds the live Vega view so it can be disposed on unmount. Without this the
+  // view keeps its RAF loop and listeners alive; once the message list is
+  // virtualized and unmounts off-screen charts, leaking them defeats the point.
+  const viewRef = useRef<{ finalize: () => void } | null>(null);
   const [embedError, setEmbedError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -29,12 +33,16 @@ export function ChartMessage({ payload, onRenderError }: Props) {
         renderer: "svg",
         actions: { export: true, editor: false, source: false },
         tooltip: { theme: "custom" },
-      }).catch((err) => {
-        console.error("Vega-Lite render error:", err);
-        const msg = String(err?.message || err);
-        setEmbedError(msg);
-        onRenderError?.(msg);
-      });
+      })
+        .then((result) => {
+          viewRef.current = result.view;
+        })
+        .catch((err) => {
+          console.error("Vega-Lite render error:", err);
+          const msg = String(err?.message || err);
+          setEmbedError(msg);
+          onRenderError?.(msg);
+        });
     };
 
     // Use ResizeObserver so chart fills width even after layout settles
@@ -53,7 +61,11 @@ export function ChartMessage({ payload, onRenderError }: Props) {
       observer.disconnect();
     }
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      viewRef.current?.finalize();
+      viewRef.current = null;
+    };
   }, [payload.vega_lite_spec]);
 
   if (!payload.vega_lite_spec || Object.keys(payload.vega_lite_spec).length === 0) {


### PR DESCRIPTION
Fixes the unbounded-memory / tab-freeze problem from #82: the chat view mounted the **entire** conversation into the DOM at once, so memory and DOM node count grew with conversation length and SQL result size until the tab got janky or crashed.

## What changed
- **Virtualize the message list** (`@tanstack/react-virtual`) — only on-screen turns (and their Vega charts) stay mounted. Dynamic measurement handles the variable heights of text / SQL tables / charts, including charts that resize after async render and the final message growing during streaming.
- **Preserve autoscroll** — the view stays pinned to the newest turn only while the user is already at the bottom; if they've scrolled up to read history, streaming and new turns no longer yank them back down.
- **Dispose Vega views on unmount** (`ChartMessage`) — `view.finalize()` in the effect cleanup, so charts scrolled out of view release their runtime. Without this the container unmounts but the Vega runtime leaks, which would defeat the point of virtualizing.
- **Keep PDF export whole** — `window.print()` needs the full transcript in the DOM, and the `@media print` CSS targets `#chat-messages > [data-print-role]` in normal flow. During export `MessageList` renders the full, unvirtualized list and `ChatView` waits two frames for that render before printing; the interactive view stays virtualized.

## Scope
- Only `MessageList` / `ChartMessage` / `ChatView` change, plus one new dependency (`@tanstack/react-virtual`, headless/small).
- No backend or API changes. The server-side payload bounds (2000-char tool results, `sql_row_limit`) are unchanged and intentional — this was a DOM/render problem, not a data-transfer one.

## Verification
- `tsc --noEmit` and `vite build` pass; `eslint` reports no new warnings on the changed files.
- Manually verified in-browser on a real conversation: long scroll stays responsive, streaming stays pinned to the bottom, scrolling up to read history isn't interrupted, and PDF export still contains the full transcript.
- Reviewers may want to confirm memory the way #82 suggests — heap snapshot + `document.getElementsByTagName('*').length` before/after on a long session.

Closes #82
