### PR TITLE
docs(hive): add Codex MCP integration example

### DIFF
--- a/connectors/hive/README.md
+++ b/connectors/hive/README.md
@@ -28,3 +28,20 @@ All configuration is read from environment variables set by the analytics-agent 
 - **NONE / NOSASL** — no credentials needed; typical for local or trusted-network deployments
 - **LDAP / PLAIN** — username + password
 - **KERBEROS** — requires `kerberos` system library (`brew install krb5` / `apt-get install libkrb5-dev`)
+
+## Codex integration
+
+To use the connector directly from Codex, add the following to `~/.codex/config.toml`.
+
+```toml
+[mcp_servers.kyuubi]
+command = "uv"
+args = ["run", "--project", "/path/to/analytics-agent/connectors/hive", "analytics-agent-connector-hive"]
+
+[mcp_servers.kyuubi.env]
+HIVE_DATABASE = "default"
+HIVE_HOST = "127.0.0.1"
+HIVE_PORT = "10000"
+HIVE_AUTH = "KERBEROS"
+HIVE_KERBEROS_SERVICE_NAME = "hive"
+```


### PR DESCRIPTION
## Summary

The Hive connector can run independently as an MCP server and integrate directly with Codex, without starting the Analytics Agent application.

This PR adds an example showing how to:

- Register the Hive connector in Codex using `mcp_servers`
- Launch the connector locally with `uv run --project`
- Connect to Apache Kyuubi
- Configure Kerberos authentication through MCP environment variables
